### PR TITLE
Get data values using series config

### DIFF
--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -49,6 +49,7 @@
           height="[[props.height.value]]"
           margin="[[props.margin.value]]"
           chart-data="[[props.chartData.value]]"
+          series-config="[[props.seriesConfig.value]]"
           scale-padding="[[props.scalePadding.value]]"
           padding-outer="[[props.paddingOuter.value]]"
           show-cell-value="[[props.showCellValue.value]]">
@@ -185,6 +186,19 @@
             value: 50
           },
         ]
+      },
+
+      seriesConfig: {
+        type: Object,
+        inputType: 'code:JSON',
+        defaultValue: {
+          'series1': {
+            'name': 'Series 1',
+            'x': 'x',
+            'y': 'y',
+            'value': 'value'
+          }
+        }
       },
 
       scalePadding: {

--- a/px-vis-heatmap-cell.html
+++ b/px-vis-heatmap-cell.html
@@ -13,6 +13,7 @@
 
       behaviors: [
         PxVisBehavior.commonMethods,
+        PxVisBehavior.completeSeriesConfig,
         PxVisBehavior.svgDefinition,
         PxVisBehaviorD3.axes,
         PxVisBehaviorD3.domainUpdate
@@ -26,6 +27,10 @@
         data: {
           type: Object,
           value: {}
+        },
+
+        seriesKey: {
+          type: String
         },
 
         /**
@@ -102,7 +107,7 @@
       },
 
       observers: [
-        '_draw(data, showCellValue, svg, x, y, domainChanged)',
+        '_draw(data, showCellValue, svg, x, y, domainChanged, completeSeriesConfig, seriesKey)',
         '_updateColors(fillColor, strokeColor)'
       ],
 
@@ -117,6 +122,9 @@
        * Draw or update the cell.
        */
       _draw: function() {
+        if (this.hasUndefinedArguments(arguments)) {
+          return;
+        }
         this.debounce('drawDebounce', function() {
           this._drawDebounced();
         }, this.drawDebounceTime);
@@ -143,8 +151,8 @@
         this._svgGroup = this.svg.append('g');
         // convert chart values to svg points
         const svgData = {
-          x: this.x(this.data.x),
-          y: this.y(this.data.y),
+          x: this.x(this._getValue('x')),
+          y: this.y(this._getValue('y')),
           width: this.x.bandwidth(),
           height: this.y.bandwidth()
         };
@@ -166,8 +174,15 @@
             y: svgData.y + svgData.height / 2
           };
           this._appendText(this._svgGroup, textPos.x, textPos.y,
-            this.data.value, this.textColor, this.textAlign, this.fontFamily, this.fontSize);
+            this._getValue('value'), this.textColor, this.textAlign, this.fontFamily, this.fontSize);
         }
+      },
+
+      /**
+       * Gets value from this.data object using keys in the completeSeriesConfig.
+       */
+      _getValue: function(key) {
+        return this.data[this.completeSeriesConfig[this.seriesKey][key]];
       },
 
       _isValidSvgPoints: function(obj) {

--- a/px-vis-heatmap-cell.html
+++ b/px-vis-heatmap-cell.html
@@ -37,19 +37,18 @@
         },
 
         /**
-         * Fill color of cell.
+         * Fill color of cell. If set, this color will override the default color
+         * which is calculated by the cell value and the color scale.
          */
         fillColor: {
-          type: String,
-          value: '#000'
+          type: String
         },
 
         /**
          * Stroke color of cell.
          */
         strokeColor: {
-          type: String,
-          value: '#FFF'
+          type: String
         },
 
         /**
@@ -155,8 +154,11 @@
           return;
         }
 
+        // calc colors
+        const fillColor = this.fillColor || this._calcCellColor();
+
         this._appendRectangle(this._svgGroup, svgData.x, svgData.y,
-          svgData.width, svgData.height, this.strokeColor, this.fillColor);
+          svgData.width, svgData.height, this.strokeColor, fillColor);
         // write value
         if (this.showCellValue) {
           const textPos = {
@@ -213,7 +215,12 @@
         if (fontSize) {
           textEl.attr('font-size', fontSize);
         }
-      }
+      },
+
+      _calcCellColor: function(value) {
+        // TODO: impl value to color
+        return '#' + ((1 << 24) * Math.random() | 0).toString(16);
+      },
 
     });
   </script>

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -76,6 +76,8 @@
         svg="[[svg]]"
         x="[[x]]"
         y="[[y]]"
+        series-key="[[seriesKey]]"
+        complete-series-config="[[completeSeriesConfig]]"
         domain-changed="[[domainChanged]]">
       </px-vis-heatmap-cell>
     </template>
@@ -111,6 +113,13 @@
         */
         chartData: {
           type: Array
+        },
+
+        /**
+         * Key that is tied to the seriesConfig.
+         */
+        seriesKey: {
+          type: String
         },
 
         /**
@@ -186,7 +195,8 @@
       observers: [
         '_updateDataExtents(chartData, chartData.*, paddingOuter)',
         '_updateSeriesConfig(seriesConfig)',
-        '_updateSeriesConfig(_colorsAreSet)'
+        '_updateSeriesConfig(_colorsAreSet)',
+        '_updateSeriesKey(seriesKey)'
       ],
 
       listeners: {
@@ -251,13 +261,25 @@
         this.debounce('_updateSeriesConfig', function() {
           // if app doesn't supply seriesConfig, use our default
           const seriesConfig = this.seriesConfig || {
-            name: 'Series',
-            x: 'x',
-            y: 'y',
-            value: 'value'
+            'series1': {
+              'name': 'Series 1',
+              'x': 'x',
+              'y': 'y',
+              'value': 'value'
+            }
           };
+          // because we only expect a single series, find the first key and assume thats the series key
+          this.set('seriesKey', Object.keys(seriesConfig)[0]);
           this.set('completeSeriesConfig', seriesConfig);
         }, 10);
+      },
+
+      _updateSeriesKey: function() {
+        if (this.hasUndefinedArguments(arguments)) {
+          return;
+        }
+        const cells = this.shadowRoot.querySelectorAll('px-vis-heatmap-cell');
+        cells.forEach((cell) => cell.seriesKey = this.seriesKey);
       },
 
       _colorsSet: function() {

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -69,12 +69,10 @@
       domain-changed="[[domainChanged]]">
     </px-vis-axis>
     <!-- heatmap cells -->
-    <template is="dom-repeat" items="[[_cellData]]">
+    <template is="dom-repeat" items="[[chartData]]">
       <px-vis-heatmap-cell
         data="[[item]]"
         show-cell-value="[[showCellValue]]"
-        fill-color="[[item.fillColor]]"
-        stroke-color="[[item.strokeColor]]"
         svg="[[svg]]"
         x="[[x]]"
         y="[[y]]"
@@ -187,7 +185,7 @@
 
       observers: [
         '_updateDataExtents(chartData, chartData.*, paddingOuter)',
-        '_updateCellData(chartData, chartData.*, domainChanged)',
+        '_updateSeriesConfig(seriesConfig)',
         '_updateSeriesConfig(_colorsAreSet)'
       ],
 
@@ -199,13 +197,6 @@
         this.set('numberOfLayers', 5);
         this.xAxisType = 'scaleBand';
         this.yAxisType = 'scaleBand';
-      },
-
-      _updateCellData: function() {
-        if (!this.chartData || !this.x || !this.y) {
-          return;
-        }
-        this.set('_cellData', this._calcCellData(this.chartData));
       },
 
       _updateDataExtents: function() {
@@ -256,42 +247,16 @@
             && extA.y[1] === extB.y[1];
       },
 
-      /**
-       * Use chartData to generate an array of cell data objects.
-       * Each object represents a cell in the heatmap.  The x and y
-       * values are svg coord locations.
-       */
-      _calcCellData: function(chartData) {
-        const cellData = [];
-        chartData.forEach((data) => {
-          cellData.push({
-            x: data.x,
-            y: data.y,
-            value: data.value,
-            fillColor: this._calcCellColor(data.value),
-            strokeColor: '#FFF'
-          });
-        });
-        return cellData;
-      },
-
-      _calcCellColor: function(value) {
-        // TODO: impl value to color
-        return '#' + ((1 << 24) * Math.random() | 0).toString(16);
-      },
-
       _updateSeriesConfig: function() {
         this.debounce('_updateSeriesConfig', function() {
-          if (this._colorsAreSet) {
-            this.set('completeSeriesConfig', {
-              'mySeries': {
-                'name': 'My-Series',
-                'x': 'x',
-                'y': 'y',
-                'color': this._getColor(0)
-              }
-            });
-          }
+          // if app doesn't supply seriesConfig, use our default
+          const seriesConfig = this.seriesConfig || {
+            name: 'Series',
+            x: 'x',
+            y: 'y',
+            value: 'value'
+          };
+          this.set('completeSeriesConfig', seriesConfig);
         }, 10);
       },
 


### PR DESCRIPTION
The seriesConfig (or completeSeriesConfig) item is used to specify object keys which are used to get data from the main chartData object.  The chartData keys were ‘x’, ‘y’, and ‘value’, but now the cell uses the seriesConfig to get these keys.

I also made a small change and moved the calcColor function into the cell class.