### PR TITLE
Rendering cells on canvas

### DIFF
--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -304,7 +304,7 @@
       const exts = {
         x: [],
         y: [],
-        val: [0, 100]
+        value: [0, 100]
       };
       for (let i = 0; i < xNum; i++) {
         exts.x.push(i);
@@ -312,6 +312,7 @@
       for (let i = 0; i < yNum; i++) {
         exts.y.push(i);
       }
+      return exts;
     }
 
   });

--- a/px-vis-heatmap-cell.html
+++ b/px-vis-heatmap-cell.html
@@ -18,6 +18,7 @@
         PxVisBehavior.completeSeriesConfig,
         PxVisBehavior.svgDefinition,
         PxVisBehaviorD3.axes,
+        PxVisBehaviorD3.canvasContext,
         PxVisBehaviorD3.domainUpdate
       ],
 
@@ -122,7 +123,7 @@
       },
 
       observers: [
-        '_draw(data, showCellValue, svg, x, y, domainChanged, completeSeriesConfig, seriesKey, colorScale)',
+        '_draw(data, showCellValue, x, y, domainChanged, completeSeriesConfig, seriesKey, colorScale)',
         '_updateColors(fillColor, strokeColor)'
       ],
 
@@ -165,8 +166,24 @@
           return;
         }
         this.debounce('drawDebounce', function() {
-          this._drawDebounced();
+          if (this.svg) {
+            this._drawDebounced();
+          } else if (this.canvasContext) {
+            this._drawDebouncedCanvas();
+          }
         }, this.drawDebounceTime);
+      },
+
+      _drawDebouncedCanvas: function() {
+        // calc colors
+        const fillColor = this.fillColor || this._calcCellColor(this._getValue('value'));
+        // draw
+        this.canvasContext.beginPath();
+        this.canvasContext.rect(this.x(this._getValue('x')),
+          this.y(this._getValue('y')), this.x.bandwidth(), this.y.bandwidth());
+        this.canvasContext.fillStyle = fillColor;
+        this.canvasContext.fill();
+        this.canvasContext.closePath();
       },
 
       /**

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -1,12 +1,13 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../px-vis/px-vis-scale.html">
-<link rel="import" href="../px-vis/px-vis-svg.html">
+<link rel="import" href="../px-vis/px-vis-svg-canvas.html">
 <link rel="import" href="../px-vis/px-vis-axis.html">
 <link rel="import" href="../px-tooltip/px-tooltip.html">
 
 <link rel="import" href="../px-vis/px-vis-behavior-colors.html">
 <link rel="import" href="../px-vis/px-vis-behavior-common.html">
 <link rel="import" href="../px-vis/px-vis-behavior-chart.html">
+<link rel="import" href="../px-vis/px-vis-behavior-d3.html">
 
 <link rel="import" href="px-vis-heatmap-cell.html">
 <link rel="import" href="px-vis-heatmap-legend.html">
@@ -16,12 +17,13 @@
 
 <dom-module id="px-vis-heatmap">
   <template>
-    <px-vis-svg
+    <px-vis-svg-canvas
       width="[[width]]"
       height="[[height]]"
       margin="[[margin]]"
-      svg="{{svg}}">
-    </px-vis-svg>
+      svg="{{svg}}"
+      canvas-context="{{canvasContext}}">
+    </px-vis-svg-canvas>
     <px-vis-scale
       id="scale"
       x-axis-type="[[xAxisType]]"
@@ -73,12 +75,13 @@
       domain-changed="[[domainChanged]]">
     </px-vis-axis>
     <!-- heatmap cells -->
-    <template is="dom-repeat" items="[[chartData]]">
+    <!-- to use svg, remove canvas-context and add svg="[[svg]]" -->
+    <!-- <template is="dom-repeat" items="[[chartData]]">
       <px-vis-heatmap-cell restamp
         data="[[item]]"
         show-cell-value="[[showCellValue]]"
         color-scale="[[_colorScale]]"
-        svg="[[svg]]"
+        canvas-context="[[canvasContext]]"
         x="[[x]]"
         y="[[y]]"
         series-key="[[seriesKey]]"
@@ -88,7 +91,7 @@
         on-mouseout="_handleCellMouseout"
         on-click="_handleCellClick">
       </px-vis-heatmap-cell>
-    </template>
+    </template> -->
 
     <px-vis-heatmap-legend
       id="legend"
@@ -126,6 +129,7 @@
         PxVisBehavior.margins,
         PxVisBehavior.observerCheck,
         PxVisBehavior.updateStylesOverride,
+        PxVisBehaviorD3.canvasContext,
         PxVisBehaviorD3.domainUpdate,
         PxVisBehaviorChart.axisConfigs,
         PxVisBehaviorChart.layers,
@@ -249,6 +253,7 @@
       },
 
       observers: [
+        '_drawCells(chartData.*, showCellValue, x, y, domainChanged, completeSeriesConfig, seriesKey, _colorScale)',
         '_updateDataExtents(chartData, chartData.*, paddingOuter)',
         '_updateSeriesConfig(seriesConfig)',
         '_updateSeriesConfig(_colorsAreSet)',
@@ -256,7 +261,7 @@
         '_yAxisConfigChanged(yAxisConfig)',
         '_legendConfigChanged(legendConfig)',
         '_updateSeriesKey(seriesKey)',
-        '_updateColorScale(chartData.*, colors, domainChanged)'
+        '_updateColorScale(chartData.*, colors.*, domainChanged)'
       ],
 
       listeners: {
@@ -268,6 +273,29 @@
         this.xAxisType = 'scaleBand';
         this.yAxisType = 'scaleBand';
         this.tooltipContent = this.$.tooltip.querySelector('#tooltipContent');
+      },
+
+      _drawCells: function() {
+        if (this.hasUndefinedArguments(arguments)) {
+          return;
+        }
+        this.canvasContext.clearRect(0, 0, this.width, this.height);
+        this.chartData.forEach((d) => {
+          this.canvasContext.beginPath();
+          this.canvasContext.rect(this.x(d.x), this.y(d.y), this.x.bandwidth(), this.y.bandwidth());
+          this.canvasContext.fillStyle = this._colorScale(d.value);
+          this.canvasContext.fill();
+          // draw value if needed
+          if (this.showCellValue) {
+            const xPos = this.x(d.x) + this.x.bandwidth() / 2;
+            const yPos = this.y(d.y) + this.y.bandwidth() / 2;
+            this.canvasContext.beginPath();
+            this.canvasContext.font = '12px Arial';
+            this.canvasContext.fillStyle = 'black';
+            this.canvasContext.textAlign = 'center';
+            this.canvasContext.fillText(d.value, xPos, yPos, this.x.bandwidth());
+          }
+        });
       },
 
       _updateDataExtents: function() {
@@ -397,6 +425,7 @@
         if (!this.colors || this.colors.length < 1) {
           return;
         }
+        // get chart min and max values
         const exts = this.chartExtents || this.dataExtents;
         if (!exts.value) {
           return;

--- a/test/basic-tests.js
+++ b/test/basic-tests.js
@@ -102,7 +102,7 @@ document.addEventListener('WebComponentsReady', () => {
     it('Just very basic but big chart', (done) => {
       expect(chart !== undefined).to.be.eql(true);
       // TODO 128x128 was too much
-      chart.chartData = generateChartData(64, 64);
+      chart.chartData = generateChartData(128, 128);
       chart.colors = ['red', 'green', 'blue', 'purple'];
 
       waitDrawUpdate(chart, () => {

--- a/test/internal-state-tests.js
+++ b/test/internal-state-tests.js
@@ -12,21 +12,22 @@ document.addEventListener('WebComponentsReady', () => {
       });
     });
 
-    it('Right amount of cells, and not leaks', (done) => {
-      expect(chart !== undefined).to.be.eql(true);
-      expect(getCells(chart).length).to.be.eql(0);
+    // TODO: uncomment when we can count cells
+    // it('Right amount of cells, and not leaks', (done) => {
+    //   expect(chart !== undefined).to.be.eql(true);
+    //   expect(getCells(chart).length).to.be.eql(0);
 
-      chart.chartData = generateChartData(8, 8);
+    //   chart.chartData = generateChartData(8, 8);
 
-      waitDrawUpdate(chart, () => {
-        expect(getCells(chart).length).to.be.eql(8 * 8);
-        chart.chartData = generateChartData(2, 2);
+    //   waitDrawUpdate(chart, () => {
+    //     expect(getCells(chart).length).to.be.eql(8 * 8);
+    //     chart.chartData = generateChartData(2, 2);
 
-        waitDrawUpdate(chart, () => {
-          expect(getCells(chart).length).to.be.eql(2 * 2);
-          done();
-        });
-      });
-    });
+    //     waitDrawUpdate(chart, () => {
+    //       expect(getCells(chart).length).to.be.eql(2 * 2);
+    //       done();
+    //     });
+    //   });
+    // });
   });
 });


### PR DESCRIPTION
Moved to using canvas for rendering all heat map cells and cell value (text).  This change has changed/removed some functionality:

 - No longer using the px-vis-heatmap-cell class
 - We manually loop thru our chartData for drawing instead of using the polymer dom-repeat (for performance)
 - Hover and tooltips no longer function