### PR TITLE
Removing tick marks from heatmap

### DIFF
--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -52,6 +52,7 @@
       title="Y Axis"
       orientation="left"
       label-position="center"
+      tick-size-inner="0"
       prevent-series-bar
       complete-series-config="[[completeSeriesConfig]]"
       muted-series=[[mutedSeries]]
@@ -69,6 +70,7 @@
       title="X Axis"
       orientation="bottom"
       label-position="center"
+      tick-size-inner="0"
       prevent-series-bar
       complete-series-config="[[completeSeriesConfig]]"
       muted-series=[[mutedSeries]]


### PR DESCRIPTION
Setting default for both x and y axis to not show the tick marks.  Can be overridden by using xAxisConfig and yAxisConfig.