### PR TITLE
Auto mobile layout when width passes breakpoint

### DIFF
--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -58,16 +58,14 @@
           x-axis-config="[[props.xAxisConfig.value]]"
           y-axis-config="[[props.yAxisConfig.value]]"
           tooltip-delay="[[props.tooltipDelay.value]]"
-          legend-config="{{props.legendConfig.value}}">
+          legend-config="{{props.legendConfig.value}}"
+          collapse-at="{{props.collapseAt.value}}"
+          on-collapsed-changed="_collapsedChanged">
         </px-vis-heatmap>
         <div>
           <input id="xSize" placeholder="X Size" />
           <input id="ySize" placeholder="Y Size" />
           <button on-click="_generateRandomData">Generate Data</button>
-        </div>
-        <div>
-          <button on-click="_desktopMode">Desktop Mode</button>
-          <button on-click="_mobileMode">Mobile Mode</button>
         </div>
       </px-demo-component>
       <!-- END Component ------------------------------------------------------>
@@ -254,6 +252,12 @@
         defaultValue: true
       },
 
+      collapseAt: {
+        type: Number,
+        inputType: 'number',
+        defaultValue: 720
+      },
+
       legendConfig: {
         type: Object,
         inputType: 'code:JSON',
@@ -333,32 +337,6 @@
       return exts;
     },
 
-    _desktopMode: function() {
-      const chart = this._getChart();
-      chart.set('margin', {
-        top: chart.margin.top,
-        right: 120,
-        bottom: 70,
-        left: chart.margin.left
-      });
-      chart.set('legendConfig', {
-        orientation: 'right'
-      });
-    },
-
-    _mobileMode: function() {
-      const chart = this._getChart();
-      chart.set('margin', {
-        top: chart.margin.top,
-        right: 10,
-        bottom: 170,
-        left: chart.margin.left
-      });
-      chart.set('legendConfig', {
-        orientation: 'bottom'
-      });
-    },
-
     _getChart: function() {
       let chart;
       if (this.shadowRoot) {
@@ -367,6 +345,25 @@
         chart = Polymer.dom(this.root).querySelector('px-vis-heatmap');
       }
       return chart;
+    },
+
+    _collapsedChanged: function(e, details) {
+      const chart = this._getChart();
+      if (details.value) {
+        chart.set('margin', {
+          top: chart.margin.top,
+          right: 10,
+          bottom: 170,
+          left: chart.margin.left
+        });
+      } else {
+        chart.set('margin', {
+          top: chart.margin.top,
+          right: 120,
+          bottom: 70,
+          left: chart.margin.left
+        });
+      }
     }
 
   });

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -20,6 +20,11 @@
   <template>
     <style include="px-vis-heatmap-styles"></style>
 
+    <!-- Media query to determine if context browser should collapse -->
+    <template is="dom-if" if="[[_collapseQueryIsValid(collapseAt)]]">
+      <iron-media-query query$="(max-width: {{_getCollapseQuery(collapseAt)}})" query-matches="{{collapsed}}"></iron-media-query>
+    </template>
+
     <px-vis-svg-canvas
       width="[[width]]"
       height="[[height]]"
@@ -109,6 +114,7 @@
       color-scale="[[_colorScale]]"
       chart-extents="[[chartExtents]]"
       data-extents="[[dataExtents]]"
+      orientation="[[_legendOrientation]]"
       complete-series-config="[[completeSeriesConfig]]"
       domain-changed="[[domainChanged]]">
     </px-vis-heatmap-legend>
@@ -257,6 +263,29 @@
           value: 100
         },
 
+        /**
+        * The width below which the context browser will collapse into a mobile
+        * friendly menu that slides up from the bottom of the page. Use a number
+        * (e.g. `450`) which will be converted to a pixel value (e.g. '450px').
+        *
+        * If no value is provided, the context browser will not collapse
+        * automatically. The collapsed attribute can also be used to manually
+        * collapse and un-collapse the context browser.
+        */
+        collapseAt: {
+          type: Number
+        },
+
+        /**
+        * Watch for changes to determine if the context browser is collapsed.
+        */
+        collapsed: {
+          type: Boolean,
+          observer: '_collapsedChanged',
+          reflectToAttribute: true,
+          notify: true
+        },
+
         _cellData: {
           type: Array
         },
@@ -268,6 +297,10 @@
 
         _colorScale: {
           type: Function
+        },
+
+        _legendOrientation: {
+          type: String
         }
 
       },
@@ -293,6 +326,29 @@
         this.xAxisType = 'scaleBand';
         this.yAxisType = 'scaleBand';
         this.tooltipContent = this.$.tooltip.querySelector('#tooltipContent');
+      },
+
+      _collapseQueryIsValid(query) {
+        if (typeof query === 'number') {
+          return true;
+        }
+        if (typeof query === 'string' && query.slice(-2) === 'px' && !isNaN(parseInt(query))) {
+          return true;
+        }
+        return false;
+      },
+
+      _getCollapseQuery(collapseAt) {
+        if (typeof collapseAt === 'number') {
+          return collapseAt + 'px';
+        }
+        if (typeof collapseAt === 'string' && collapseAt.slice(-2) === 'px' || !isNaN(parseInt(collapseAt))) {
+          return collapseAt;
+        }
+      },
+
+      _collapsedChanged() {
+        this.set('_legendOrientation', this.collapsed ? 'bottom' : 'right');
       },
 
       _drawCells: function() {


### PR DESCRIPTION
Added prop ‘collapseAt’ that specifies when the view should collapse into the mobile view.  There is also a ‘collapse’ property that can be listened on in order for the app to do things like update margins (on-collapsed-changed).