### PR TITLE
Adding showLegend boolean prop

### DIFF
--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -63,6 +63,7 @@
               x-axis-config="{{props.xAxisConfig.value}}"
               y-axis-config="{{props.yAxisConfig.value}}"
               tooltip-delay="{{props.tooltipDelay.value}}"
+              show-legend="{{props.showLegend.value}}"
               legend-config="{{props.legendConfig.value}}"
               collapse-at="{{props.collapseAt.value}}"
               on-collapsed-changed="_collapsedChanged">
@@ -285,6 +286,12 @@
         type: Number,
         inputType: 'number',
         defaultValue: 720
+      },
+
+      showLegend: {
+        type: Boolean,
+        inputType: 'toggle',
+        defaultValue: true
       },
 
       legendConfig: {

--- a/px-vis-heatmap-legend.html
+++ b/px-vis-heatmap-legend.html
@@ -53,10 +53,12 @@
         PxVisBehavior.axisTypes,
         PxVisBehavior.baseSize,
         PxVisBehavior.chartExtents,
+        PxVisBehavior.commonMethods,
         PxVisBehavior.completeSeriesConfig,
         PxVisBehavior.dataExtents,
         PxVisBehavior.margins,
         PxVisBehavior.observerCheck,
+        PxVisBehavior.svgDefinition,
         PxVisBehaviorD3.domainUpdate,
         PxVisBehaviorChart.axisConfigs,
         PxVisBehaviorChart.subConfiguration
@@ -215,6 +217,16 @@
         '_updateAxisExtents(_axisDomainChanged, _axisX, _axisY, colorScale)',
         '_updateAxisOrientation(orienation)'
       ],
+
+      detached: function() {
+        // remove gradient and rectangle drawings
+        if (!this._isObjEmpty(this._gradientDef)) {
+          this._gradientDef.remove();
+        }
+        if (!this._isObjEmpty(this._rect)) {
+          this._rect.remove();
+        }
+      },
 
       _defineGradient: function() {
         if (this.hasUndefinedArguments(arguments)) {

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -117,21 +117,23 @@
         </px-vis-heatmap-cell>
       </template> -->
 
-      <px-vis-heatmap-legend
-        id="legend"
-        svg="[[svg]]"
-        x="[[x]]"
-        y="[[y]]"
-        margin="[[margin]]"
-        width="[[_internalWidth]]"
-        height="[[_internalHeight]]"
-        color-scale="[[_colorScale]]"
-        chart-extents="[[chartExtents]]"
-        data-extents="[[dataExtents]]"
-        orientation="[[_legendOrientation]]"
-        complete-series-config="[[completeSeriesConfig]]"
-        domain-changed="[[domainChanged]]">
-      </px-vis-heatmap-legend>
+      <template is="dom-if" if="[[showLegend]]" restamp>
+        <px-vis-heatmap-legend
+          id="legend"
+          svg="[[svg]]"
+          x="[[x]]"
+          y="[[y]]"
+          margin="[[margin]]"
+          width="[[_internalWidth]]"
+          height="[[_internalHeight]]"
+          color-scale="[[_colorScale]]"
+          chart-extents="[[chartExtents]]"
+          data-extents="[[dataExtents]]"
+          orientation="[[_legendOrientation]]"
+          complete-series-config="[[completeSeriesConfig]]"
+          domain-changed="[[domainChanged]]">
+        </px-vis-heatmap-legend>
+      </template>
 
     </div><!-- /wrapper -->
 
@@ -228,6 +230,11 @@
         squareMode: {
           type: Boolean,
           value: false
+        },
+
+        showLegend: {
+          type: Boolean,
+          value: true
         },
 
         /**
@@ -589,7 +596,18 @@
         if (this.hasUndefinedArguments(arguments)) {
           return;
         }
-        this._applyConfigToElement(legendConfig, this.$.legend);
+        // debouncing because this gets called before dom-if that instantiates legend happens
+        this.debounce('legend-config-changed', function() {
+          let legend;
+          if (this.shadowRoot) {
+            legend = this.shadowRoot.querySelector('px-vis-heatmap-legend');
+          } else {
+            legend = Polymer.dom(this.root).querySelector('px-vis-heatmap-legend');
+          }
+          if (legend) {
+            this._applyConfigToElement(legendConfig, legend);
+          }
+        }.bind(this), 10);
       },
 
       _handleCellMouseover: function(e, details) {


### PR DESCRIPTION
Legend can be hidden by setting showLegend to false.  Added short debounce because the legendConfig wasn’t being applied on the first update (seems like the dom-if delays the creation of the legend element).