### PR TITLE
Adding theming

### DIFF
--- a/css/px-vis-heatmap-dark-theme-styles.html
+++ b/css/px-vis-heatmap-dark-theme-styles.html
@@ -1,0 +1,7 @@
+<dom-module id="px-vis-heatmap-dark-theme-styles">
+<template>
+<style>
+html{--px-vis-axis-color:#b6c3cc;--px-vis-axis-title-color:#b6c3cc;--px-tooltip-text-color:#b6c3cc;--px-tooltip-background-color:#23343f;--px-tooltip-border-color:#0c1419;--px-vis-heatmap-cell-border-color:#2c404c;--px-vis-heatmap-cell-border-width:1px;--px-vis-heatmap-cell-text-color:#e2e8ed;--px-vis-heatmap-cell-text-size:12px;--px-vis-heatmap-colors-0:#7da7c3;--px-vis-heatmap-colors-1:#8eb47c;--px-vis-heatmap-colors-2:#e1d75e;--px-vis-heatmap-legend-border-color:#2c404c;--px-vis-heatmap-legend-border-width:1px}
+</style>
+</template>
+</dom-module>

--- a/css/px-vis-heatmap-light-theme-styles.html
+++ b/css/px-vis-heatmap-light-theme-styles.html
@@ -1,0 +1,7 @@
+<dom-module id="px-vis-heatmap-light-theme-styles">
+<template>
+<style>
+html{--px-vis-axis-color:#677e8c;--px-vis-axis-title-color:#677e8c;--px-tooltip-text-color:#677e8c;--px-tooltip-background-color:white;--px-tooltip-border-color:#d8e0e5;--px-vis-heatmap-cell-border-color:#d8e0e5;--px-vis-heatmap-cell-border-width:1px;--px-vis-heatmap-cell-text-color:#121f26;--px-vis-heatmap-cell-text-size:12px;--px-vis-heatmap-colors-0:#4882a8;--px-vis-heatmap-colors-1:#659540;--px-vis-heatmap-colors-2:#d3c800;--px-vis-heatmap-legend-border-color:#d8e0e5;--px-vis-heatmap-legend-border-width:1px}
+</style>
+</template>
+</dom-module>

--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -55,7 +55,6 @@
               chart-data="{{props.chartData.value}}"
               chart-extents="{{props.chartExtents.value}}"
               square-mode="{{props.squareMode.value}}"
-              colors="{{props.colors.value}}"
               series-config="{{props.seriesConfig.value}}"
               scale-padding="{{props.scalePadding.value}}"
               padding-outer="{{props.paddingOuter.value}}"
@@ -245,16 +244,6 @@
           y: ['Cat 1', 'Cat 2', 'Cat 3'],
           value: [0, 100]
         }
-      },
-
-      colors: {
-        type: Array,
-        inputType: 'code:JSON',
-        defaultValue: [
-          'blue',
-          'violet',
-          'red'
-        ]
       },
 
       seriesConfig: {

--- a/index.html
+++ b/index.html
@@ -50,13 +50,24 @@
     <link rel="import" href="../px-theme/px-theme-styles.html">
     <style include="px-theme-styles" is="custom-style"></style>
 
+    <link rel="import" href="css/px-vis-heatmap-dark-theme-styles.html">
+    <link rel="import" href="css/px-vis-heatmap-light-theme-styles.html">
+
+    <custom-style id="px-vis-heatmap-theme-styles">
+      <style include="px-vis-heatmap-light-theme-styles" is="custom-style"></style>
+    </custom-style>
+
+    <custom-style id="px-dark-demo-theme-styles">
+      <!-- <style include="px-dark-demo-theme-styles" is="custom-style"></style> -->
+    </custom-style>
+
     <!--
       Load dark theme files for later use. Stamp dynamic theme switcher, which
       listens for theme update messages from the parent page and applies them.
     -->
-    <link defer rel="import" href="../px-dark-theme/px-dark-theme-styles.html">
-    <link defer rel="import" href="../px-dark-demo-theme/px-dark-demo-theme-styles.html">
-    <link defer rel="import" href="../px-demo/px-demo-theme-switcher.html"/>
+    <link rel="import" href="../px-dark-theme/px-dark-theme-styles.html">
+    <link rel="import" href="../px-dark-demo-theme/px-dark-demo-theme-styles.html">
+    <link rel="import" href="../px-demo/px-demo-theme-switcher.html"/>
     <px-demo-theme-switcher-frame id="themeMessenger" origin="https://www.predix-ui.com"></px-demo-theme-switcher-frame>
     <px-demo-theme-switcher id="themeSwitcher"></px-demo-theme-switcher>
     <script>
@@ -67,6 +78,44 @@
           switcher.isDarkTheme = evt.detail.value;
         });
       })();
+
+      // TODO: remove custom theme toggle when integrated into predix online demos
+      let dark = false;
+      let customStyle = document.getElementById('px-vis-heatmap-theme-styles');
+      let darkStyle = document.getElementById('px-dark-demo-theme-styles');
+      // add toggle button
+      const toggleThemeBtn = document.createElement('button');
+      toggleThemeBtn.innerHTML = 'Light Theme';
+      toggleThemeBtn.onclick = toggleTheme;
+      // TODO fix properly, now to allow IE11 to work
+      if (document.body.prepend) {
+        document.body.prepend(toggleThemeBtn);
+      }
+      // toggle theme func
+      function toggleTheme(e) {
+        if (e) {
+          e.target.innerHTML = dark ? 'Light Theme' : 'Dark Theme';
+        }
+        dark = !dark;
+        const newCustomStyle = document.createElement('custom-style');
+        newCustomStyle.innerHTML = `<style include="px-vis-heatmap-${dark ? 'dark' : 'light'}-theme-styles" is="custom-style"></style>`;
+        document.head.appendChild(newCustomStyle);
+        customStyle.remove();
+        customStyle = newCustomStyle;
+        // add dark predix demo theme
+        darkStyle.remove();
+        darkStyle = document.createElement('custom-style');
+        darkStyle.innerHTML = dark ? `<style include="px-dark-demo-theme-styles" is="custom-style"></style>` : null;
+        document.head.append(darkStyle);
+        // notify component of style changes
+        const demo = document.querySelector('px-vis-heatmap-demo');
+        if (demo && demo.shadowRoot) {
+          demo.shadowRoot.querySelector('px-vis-heatmap').updateStyles();
+        } else if (demo) {
+          Polymer.dom(demo.root).querySelector('px-vis-heatmap').updateStyles();
+        }
+      }
+
     </script>
 
     <!--

--- a/px-vis-heatmap-legend.html
+++ b/px-vis-heatmap-legend.html
@@ -59,6 +59,7 @@
         PxVisBehavior.margins,
         PxVisBehavior.observerCheck,
         PxVisBehavior.svgDefinition,
+        PxVisBehavior.updateStylesOverride,
         PxVisBehaviorD3.domainUpdate,
         PxVisBehaviorChart.axisConfigs,
         PxVisBehaviorChart.subConfiguration
@@ -217,14 +218,22 @@
          */
         _gradientDef: {
           type: Object
+        },
+
+        /**
+         * Observe changes to this in order to know when css vars have changed.
+         */
+        _stylesResolved: {
+          type: Boolean,
+          value: false
         }
 
       },
 
       observers: [
-        '_defineGradient(colorScale)',
-        '_updateRectangePosition(_rect, orientation, width, gapSize, margin.*, domainChanged)',
-        '_drawRectangle(orientation, width, height, legendWidth, domainChanged)',
+        '_defineGradient(colorScale, _stylesResolved)',
+        '_updateRectangePosition(_rect, orientation, width, gapSize, margin.*, domainChanged, _stylesResolved)',
+        '_drawRectangle(orientation, width, height, legendWidth, domainChanged, _stylesResolved)',
         '_yAxisConfigChanged(yAxisConfig)',
         '_updateAxisScale(orientation, _axisX, _axisY)',
         '_updateAxisMargin(orientation, width, height, legendWidth, gapSize, margin.*, x, y, domainChanged)',
@@ -299,6 +308,8 @@
           this._rect = this.svg.append('rect')
             .attr('width', this.legendWidth)
             .attr('height', height)
+            .attr('stroke', this.borderColor)
+            .attr('stroke-width', this.borderWidth)
             .style('fill', 'url(#gradient)');
         }.bind(this), this.drawDebounceTime);
       },
@@ -395,16 +406,20 @@
       },
 
       _resolveCssVars: function() {
-        // get series config obj
-        const seriesConfig = this.completeSeriesConfig || {};
-        const config = seriesConfig[this.seriesKey] || {};
-        // resolve all css vars
-        this.borderColor = config.cellBorderColor
-          || this._checkThemeVariable('--px-vis-heatmap-legend-border-color', '#FFF');
-        this.borderWidth = config.cellBorderWidth
-          || this._checkThemeVariable('--px-vis-heatmap-legend-border-width', '0');
-        // notify children
-        this.$.yAxis.updateStyles();
+        this.debounce('resolve-css-vars', function() {
+          // get series config obj
+          const seriesConfig = this.completeSeriesConfig || {};
+          const config = seriesConfig[this.seriesKey] || {};
+          // resolve all css vars
+          this.borderColor = config.legendBorderColor
+            || this._checkThemeVariable('--px-vis-heatmap-legend-border-color', '#FFF');
+          this.borderWidth = config.legendBorderWidth
+            || this._checkThemeVariable('--px-vis-heatmap-legend-border-width', '0');
+          // notify children
+          this.$.yAxis.updateStyles();
+          // notify that style vars have changed
+          this.set('_stylesResolved', !this._stylesResolved);
+        }.bind(this), 10);
       }
 
     });

--- a/px-vis-heatmap-legend.html
+++ b/px-vis-heatmap-legend.html
@@ -135,6 +135,20 @@
         },
 
         /**
+         * Color of border surrounding legend. Set by series config or css var.
+         */
+        borderColor: {
+          type: String
+        },
+
+        /**
+         * Width of border surrounding legend. Set by series config or css var.
+         */
+        borderWidth: {
+          type: String
+        },
+
+        /**
         * This component doesn't use chartData, but some px-vis
         * comps require a valid chart data object.
         */
@@ -215,7 +229,8 @@
         '_updateAxisScale(orientation, _axisX, _axisY)',
         '_updateAxisMargin(orientation, width, height, legendWidth, gapSize, margin.*, x, y, domainChanged)',
         '_updateAxisExtents(_axisDomainChanged, _axisX, _axisY, colorScale)',
-        '_updateAxisOrientation(orienation)'
+        '_updateAxisOrientation(orienation)',
+        '_resolveCssVars(_stylesUpdated)'
       ],
 
       detached: function() {
@@ -377,6 +392,19 @@
           return;
         }
         this._applyConfigToElement(yAxisConfig, this.$.yAxis);
+      },
+
+      _resolveCssVars: function() {
+        // get series config obj
+        const seriesConfig = this.completeSeriesConfig || {};
+        const config = seriesConfig[this.seriesKey] || {};
+        // resolve all css vars
+        this.borderColor = config.cellBorderColor
+          || this._checkThemeVariable('--px-vis-heatmap-legend-border-color', '#FFF');
+        this.borderWidth = config.cellBorderWidth
+          || this._checkThemeVariable('--px-vis-heatmap-legend-border-width', '0');
+        // notify children
+        this.$.yAxis.updateStyles();
       }
 
     });

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -639,6 +639,14 @@
         }.bind(this), 10);
       },
 
+      _getLegend: function() {
+        if (this.shadowRoot) {
+          return this.shadowRoot.querySelector('px-vis-heatmap-legend');
+        } else {
+          return Polymer.dom(this.root).querySelector('px-vis-heatmap-legend');
+        }
+      },
+
       _handleCellMouseover: function(e, details) {
         // show over cell value if available, otherwise over entire cell
         const el = details.cell.getSvgTextElement() || details.cell.getSvgElement();
@@ -717,7 +725,10 @@
         // notify children
         this.$.xAxis.updateStyles();
         this.$.yAxis.updateStyles();
-
+        const legend = this._getLegend();
+        if (legend) {
+          legend.updateStyles();
+        }
       },
 
       _colorsSet: function() {

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -370,12 +370,20 @@
 
         _internalHeight: {
           type: Number
+        },
+
+        /**
+         * Observe changes to this in order to know when css vars have changed.
+         */
+        _stylesResolved: {
+          type: Boolean,
+          value: false
         }
 
       },
 
       observers: [
-        '_drawCells(margin, chartData.*, showCellValue, x, y, domainChanged, completeSeriesConfig, seriesKey, _colorScale)',
+        '_drawCells(margin, chartData.*, showCellValue, x, y, domainChanged, completeSeriesConfig, seriesKey, _colorScale, _stylesResolved)',
         '_updateDataExtents(chartData, chartData.*, paddingOuter)',
         '_updateSeriesConfig(seriesConfig)',
         '_updateSeriesConfig(_colorsAreSet)',
@@ -411,13 +419,16 @@
             this.canvasContext.rect(this.x(d.x), this.y(d.y), this.x.bandwidth(), this.y.bandwidth());
             this.canvasContext.fillStyle = this._colorScale(d.value);
             this.canvasContext.fill();
+            this.canvasContext.strokeStyle = this.cellBorderColor;
+            this.canvasContext.lineWidth = this.cellBorderWidth.replace('px', '');
+            this.canvasContext.stroke();
             // draw value if needed
             if (this.showCellValue) {
               const xPos = this.x(d.x) + this.x.bandwidth() / 2;
               const yPos = this.y(d.y) + this.y.bandwidth() / 2;
               this.canvasContext.beginPath();
-              this.canvasContext.font = '12px Arial';
-              this.canvasContext.fillStyle = 'black';
+              this.canvasContext.font = this.cellTextSize + ' Arial';
+              this.canvasContext.fillStyle = this.cellTextColor;
               this.canvasContext.textAlign = 'center';
               this.canvasContext.textBaseline = 'middle';
               this.canvasContext.fillText(d.value, xPos, yPos, this.x.bandwidth());
@@ -710,25 +721,29 @@
       },
 
       _resolveCssVars: function() {
-        // get series config obj
-        const seriesConfig = this.completeSeriesConfig || {};
-        const config = seriesConfig[this.seriesKey] || {};
-        // resolve all css vars
-        this.cellBorderColor = config.cellBorderColor
-          || this._checkThemeVariable('--px-vis-heatmap-cell-border-color', '#FFF');
-        this.cellBorderWidth = config.cellBorderWidth
-          || this._checkThemeVariable('--px-vis-heatmap-cell-border-width', '0');
-        this.cellTextColor = config.cellTextColor
-          || this._checkThemeVariable('--px-vis-heatmap-cell-text-color', '#000');
-        this.cellTextSize = config.cellTextSize
-          || this._checkThemeVariable('--px-vis-heatmap-cell-text-size', '12px');
-        // notify children
-        this.$.xAxis.updateStyles();
-        this.$.yAxis.updateStyles();
-        const legend = this._getLegend();
-        if (legend) {
-          legend.updateStyles();
-        }
+        this.debounce('resolve-css-vars', function() {
+          // get series config obj
+          const seriesConfig = this.completeSeriesConfig || {};
+          const config = seriesConfig[this.seriesKey] || {};
+          // resolve all css vars
+          this.cellBorderColor = config.cellBorderColor
+            || this._checkThemeVariable('--px-vis-heatmap-cell-border-color', '#FFF');
+          this.cellBorderWidth = config.cellBorderWidth
+            || this._checkThemeVariable('--px-vis-heatmap-cell-border-width', '0');
+          this.cellTextColor = config.cellTextColor
+            || this._checkThemeVariable('--px-vis-heatmap-cell-text-color', '#000');
+          this.cellTextSize = config.cellTextSize
+            || this._checkThemeVariable('--px-vis-heatmap-cell-text-size', '12px');
+          // notify children
+          this.$.xAxis.updateStyles();
+          this.$.yAxis.updateStyles();
+          const legend = this._getLegend();
+          if (legend) {
+            legend.updateStyles();
+          }
+          // notify that style vars have changed
+          this.set('_stylesResolved', !this._stylesResolved);
+        }.bind(this), 10);
       },
 
       _colorsSet: function() {

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -265,13 +265,7 @@
          * Colors to use for the heatmap.
          */
         colors: {
-          type: Array,
-          value: function() {
-            return [
-              'lightblue',
-              'blue'
-            ];
-          }
+          type: Array
         },
 
         /**
@@ -354,6 +348,10 @@
         _colorsAreSet: {
           type: Boolean,
           value: false
+        },
+
+        _internalColors: {
+          type: Array
         },
 
         _colorScale: {
@@ -726,14 +724,16 @@
           const seriesConfig = this.completeSeriesConfig || {};
           const config = seriesConfig[this.seriesKey] || {};
           // resolve all css vars
-          this.cellBorderColor = config.cellBorderColor
-            || this._checkThemeVariable('--px-vis-heatmap-cell-border-color', '#FFF');
-          this.cellBorderWidth = config.cellBorderWidth
-            || this._checkThemeVariable('--px-vis-heatmap-cell-border-width', '0');
-          this.cellTextColor = config.cellTextColor
-            || this._checkThemeVariable('--px-vis-heatmap-cell-text-color', '#000');
-          this.cellTextSize = config.cellTextSize
-            || this._checkThemeVariable('--px-vis-heatmap-cell-text-size', '12px');
+          this.set('cellBorderColor', config.cellBorderColor
+            || this._checkThemeVariable('--px-vis-heatmap-cell-border-color', '#FFF'));
+          this.set('cellBorderWidth', config.cellBorderWidth
+            || this._checkThemeVariable('--px-vis-heatmap-cell-border-width', '0'));
+          this.set('cellTextColor', config.cellTextColor
+            || this._checkThemeVariable('--px-vis-heatmap-cell-text-color', '#000'));
+          this.set('cellTextSize', config.cellTextSize
+            || this._checkThemeVariable('--px-vis-heatmap-cell-text-size', '12px'));
+          this.set('colors', config.colors
+            || this._checkThemeColors('--px-vis-heatmap-colors-', ['lightblue', 'blue']));
           // notify children
           this.$.xAxis.updateStyles();
           this.$.yAxis.updateStyles();
@@ -744,6 +744,23 @@
           // notify that style vars have changed
           this.set('_stylesResolved', !this._stylesResolved);
         }.bind(this), 10);
+      },
+
+      _checkThemeColors: function(rulePrefix, defaultColors) {
+        let colors = [];
+        let color = 'none';
+        let i = 0;
+        while (color !== undefined) {
+          color = this._checkThemeVariable(rulePrefix + i);
+          if (color !== undefined) {
+            colors.push(color);
+          }
+          i++;
+        }
+        if (!colors || colors.length < 1) {
+          colors = defaultColors;
+        }
+        return colors;
       },
 
       _colorsSet: function() {

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -319,6 +319,34 @@
           notify: true
         },
 
+        /**
+         * Color of cell border. Set by series config object or css var.
+         */
+        cellBorderColor: {
+          type: String
+        },
+
+        /**
+         * Width of cell border. Set by series config object or css var.
+         */
+        cellBorderWidth: {
+          type: String
+        },
+
+        /**
+         * Color of text used for cell value. Set by series config object or css var.
+         */
+        cellTextColor: {
+          type: String
+        },
+
+        /**
+         * Size of text used for cell value. Set by series config object or css var.
+         */
+        cellTextSize: {
+          type: String
+        },
+
         _cellData: {
           type: Array
         },
@@ -356,7 +384,8 @@
         '_updateInternalSize(squareMode, width, height, margin.*)',
         '_xAxisConfigChanged(xAxisConfig)',
         '_yAxisConfigChanged(yAxisConfig)',
-        '_legendConfigChanged(legendConfig)'
+        '_legendConfigChanged(legendConfig)',
+        '_resolveCssVars(_stylesUpdated)'
       ],
 
       listeners: {
@@ -670,6 +699,25 @@
         // use parseFloat to be safe of XSS
         msg += cell._getValue('value');
         return msg;
+      },
+
+      _resolveCssVars: function() {
+        // get series config obj
+        const seriesConfig = this.completeSeriesConfig || {};
+        const config = seriesConfig[this.seriesKey] || {};
+        // resolve all css vars
+        this.cellBorderColor = config.cellBorderColor
+          || this._checkThemeVariable('--px-vis-heatmap-cell-border-color', '#FFF');
+        this.cellBorderWidth = config.cellBorderWidth
+          || this._checkThemeVariable('--px-vis-heatmap-cell-border-width', '0');
+        this.cellTextColor = config.cellTextColor
+          || this._checkThemeVariable('--px-vis-heatmap-cell-text-color', '#000');
+        this.cellTextSize = config.cellTextSize
+          || this._checkThemeVariable('--px-vis-heatmap-cell-text-size', '12px');
+        // notify children
+        this.$.xAxis.updateStyles();
+        this.$.yAxis.updateStyles();
+
       },
 
       _colorsSet: function() {

--- a/sass/px-vis-heatmap-dark-theme.scss
+++ b/sass/px-vis-heatmap-dark-theme.scss
@@ -6,7 +6,7 @@
 
 html {
   // axis
-  --px-vis-axis-color: $gray10;
+  --px-vis-axis-color: $gray5;
   --px-vis-axis-title-color: $gray5;
 
   // tooltip
@@ -19,6 +19,9 @@ html {
   --px-vis-heatmap-cell-border-width: 1px;
   --px-vis-heatmap-cell-text-color: $gray2;
   --px-vis-heatmap-cell-text-size: 12px;
+  --px-vis-heatmap-colors-0: $aqua4;
+  --px-vis-heatmap-colors-1: $green4;
+  --px-vis-heatmap-colors-2: $yellow4;
 
   // heatmap legend
   --px-vis-heatmap-legend-border-color: $gray15;

--- a/sass/px-vis-heatmap-dark-theme.scss
+++ b/sass/px-vis-heatmap-dark-theme.scss
@@ -2,10 +2,25 @@
  * CSS variables for Predix Light Theme
  */
 
- @import "px-colors-design/_settings.colors.scss";
+@import "px-colors-design/_settings.colors.scss";
 
- html {
-   // axis
-   --px-vis-axis-color: $gray10;
-   --px-vis-axis-title-color: $gray5;
- }
+html {
+  // axis
+  --px-vis-axis-color: $gray10;
+  --px-vis-axis-title-color: $gray5;
+
+  // tooltip
+  --px-tooltip-text-color: $gray5;
+  --px-tooltip-background-color: $gray16;
+  --px-tooltip-border-color: $gray19;
+
+  // heatmap
+  --px-vis-heatmap-cell-border-color: $gray15;
+  --px-vis-heatmap-cell-border-width: 1px;
+  --px-vis-heatmap-cell-text-color: $gray2;
+  --px-vis-heatmap-cell-text-size: 12px;
+
+  // heatmap legend
+  --px-vis-heatmap-legend-border-color: $gray15;
+  --px-vis-heatmap-legend-border-width: 1px;
+}

--- a/sass/px-vis-heatmap-light-theme.scss
+++ b/sass/px-vis-heatmap-light-theme.scss
@@ -2,11 +2,26 @@
  * CSS variables for Predix Light Theme
  */
 
- @import "px-colors-design/_settings.colors.scss";
+@import "px-colors-design/_settings.colors.scss";
 
 
- html {
-   // axis
-   --px-vis-axis-color: $gray10;
-   --px-vis-axis-title-color: $gray10;
- }
+html {
+  // axis
+  --px-vis-axis-color: $gray10;
+  --px-vis-axis-title-color: $gray10;
+
+  // tooltip
+  --px-tooltip-text-color: $gray10;
+  --px-tooltip-background-color: $white;
+  --px-tooltip-border-color: $gray3;
+
+  // heatmap
+  --px-vis-heatmap-cell-border-color: $gray3;
+  --px-vis-heatmap-cell-border-width: 1px;
+  --px-vis-heatmap-cell-text-color: $gray18;
+  --px-vis-heatmap-cell-text-size: 12px;
+
+  // heatmap legend
+  --px-vis-heatmap-legend-border-color: $gray3;
+  --px-vis-heatmap-legend-border-width: 1px;
+}

--- a/sass/px-vis-heatmap-light-theme.scss
+++ b/sass/px-vis-heatmap-light-theme.scss
@@ -20,6 +20,9 @@ html {
   --px-vis-heatmap-cell-border-width: 1px;
   --px-vis-heatmap-cell-text-color: $gray18;
   --px-vis-heatmap-cell-text-size: 12px;
+  --px-vis-heatmap-colors-0: $aqua6;
+  --px-vis-heatmap-colors-1: $green6;
+  --px-vis-heatmap-colors-2: $yellow6;
 
   // heatmap legend
   --px-vis-heatmap-legend-border-color: $gray3;


### PR DESCRIPTION
Adding light and dark themes.  One major note is that style props can only be defined in the css vars or in the series config object.  This includes the colors used, so as of now you cannot use heatmap.colors to directly set the colors (will be overridden).  We can add this later if needed.