### PR TITLE
Adding spacing to axis labels and removing axis lines

### DIFF
--- a/px-vis-heatmap-legend.html
+++ b/px-vis-heatmap-legend.html
@@ -37,10 +37,11 @@
       height="[[height]]"
       orientation="[[_axisOrientation]]"
       label-position="center"
+      axis-tick-color="transparent"
+      axis-line-color="transparent"
       prevent-series-bar
       complete-series-config="[[completeSeriesConfig]]"
       muted-series=[[mutedSeries]]
-      tick-size-inner="[[tickSizeInner]]"
       domain-changed="[[_axisDomainChanged]]">
     </px-vis-axis>
   </template>
@@ -117,14 +118,6 @@
         drawDebounceTime: {
           type: Number,
           value: 100
-        },
-
-        /**
-         * Length of the yAxis tick marks.
-         */
-        tickSizeInner: {
-          type: Number,
-          value: 0
         },
 
         /**

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -104,7 +104,8 @@
         height="[[_internalHeight]]"
         orientation="left"
         label-position="center"
-        tick-size-inner="0"
+        axis-tick-color="transparent"
+        axis-line-color="transparent"
         prevent-series-bar
         complete-series-config="[[completeSeriesConfig]]"
         muted-series=[[mutedSeries]]
@@ -121,7 +122,8 @@
         height="[[_internalHeight]]"
         orientation="bottom"
         label-position="center"
-        tick-size-inner="0"
+        axis-tick-color="transparent"
+        axis-line-color="transparent"
         prevent-series-bar
         complete-series-config="[[completeSeriesConfig]]"
         muted-series=[[mutedSeries]]


### PR DESCRIPTION
Removing axis lines and changing the way we hide tick marks in order to keep the default label/axis spacing.