### PR TITLE
Adding custom column

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,5 +17,8 @@
     "PxVisBehaviorChart": false,
     "PxVisBehaviorD3": false,
     "Vaadin": false
+  },
+  "rules": {
+    "max-len": 0
   }
 }

--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -299,8 +299,8 @@
         type: Object,
         inputType: 'code:JSON',
         defaultValue: {
-          columnName: 'Accuracy',
-          columnWidth: 100,
+          columnLabel: 'Accuracy',
+          columnWidth: 75,
           columnData: [
             {
               y: 'Asset 1',

--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -56,7 +56,7 @@
               chart-data="{{props.chartData.value}}"
               chart-extents="{{props.chartExtents.value}}"
               show-custom-column="{{props.showCustomColumn.value}}"
-              custom-column-data="{{props.customColumnData.value}}"
+              custom-column-config="{{props.customColumnConfig.value}}"
               square-mode="{{props.squareMode.value}}"
               series-config="{{props.seriesConfig.value}}"
               scale-padding="{{props.scalePadding.value}}"
@@ -295,12 +295,13 @@
         defaultValue: true
       },
 
-      customColumnData: {
+      customColumnConfig: {
         type: Object,
         inputType: 'code:JSON',
         defaultValue: {
-          name: 'Accuracy',
-          values: [
+          columnName: 'Accuracy',
+          columnWidth: 100,
+          columnData: [
             {
               y: 'Asset 1',
               value: 10

--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -55,6 +55,8 @@
               margin="{{props.margin.value}}"
               chart-data="{{props.chartData.value}}"
               chart-extents="{{props.chartExtents.value}}"
+              show-custom-column="{{props.showCustomColumn.value}}"
+              custom-column-data="{{props.customColumnData.value}}"
               square-mode="{{props.squareMode.value}}"
               series-config="{{props.seriesConfig.value}}"
               scale-padding="{{props.scalePadding.value}}"
@@ -260,7 +262,7 @@
             x: '3:00',
             y: 'Asset 3',
             value: 100
-          },
+          }
         ]
       },
 
@@ -284,6 +286,34 @@
             'y': 'y',
             'value': 'value'
           }
+        }
+      },
+
+      showCustomColumn: {
+        type: Boolean,
+        inputType: 'toggle',
+        defaultValue: true
+      },
+
+      customColumnData: {
+        type: Object,
+        inputType: 'code:JSON',
+        defaultValue: {
+          name: 'Accuracy',
+          values: [
+            {
+              y: 'Asset 1',
+              value: 10
+            },
+            {
+              y: 'Asset 2',
+              value: 20
+            },
+            {
+              y: 'Asset 3',
+              value: 30
+            }
+          ]
         }
       },
 

--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -127,15 +127,6 @@
   Polymer({
     is: 'px-vis-heatmap-demo',
 
-    ready: function() {
-      // TODO: remove - using for easier dev
-      if (this.shadowRoot) {
-        window.chart = this.shadowRoot.querySelector('px-vis-heatmap');
-      } else {
-        window.chart = Polymer.dom(this.root).querySelector('px-vis-heatmap');
-      }
-    },
-
     properties: {
       props: {
         type: Object,

--- a/px-vis-heatmap-custom-column.html
+++ b/px-vis-heatmap-custom-column.html
@@ -36,7 +36,7 @@
           type: Array
         },
 
-        columnName: {
+        columnLabel: {
           type: String,
         },
 
@@ -59,6 +59,29 @@
         borderWidth: {
           type: String,
           value: '1px'
+        },
+
+        textColor: {
+          type: String,
+          value: 'black'
+        },
+
+        textSize: {
+          type: String,
+          value: '12px'
+        },
+
+        columnLabelTextColor: {
+          type: String
+        },
+
+        columnLabelTextSize: {
+          type: String
+        },
+
+        columnLabelSpacing: {
+          type: Number,
+          value: 15
         },
 
         /**
@@ -84,7 +107,8 @@
       },
 
       observers: [
-        '_drawElement(columnWidth, columnData.*, columnName, borderColor, borderWidth, margin.*, x, y, domainChanged, completeSeriesConfig, seriesKey, _stylesResolved)',
+        '_drawElement(columnWidth, columnData.*, columnLabel, borderColor, borderWidth, margin.*, x, y, domainChanged, completeSeriesConfig, seriesKey, _stylesResolved)',
+        '_resolveCssVars(_stylesUpdated)'
       ],
 
       detached: function() {
@@ -118,18 +142,23 @@
           // draw row lines in column
           exts.y.forEach(function(yVal, i) {
             const yPos = this.y(yVal);
-            this._appendSvgLine(this._svgGroup, 0, this.columnWidth,
-              yPos, yPos, this.borderColor, this.borderWidth);
+            this._appendSvgLine(this._svgGroup, 0, this.columnWidth, yPos, yPos);
           }.bind(this));
           // draw values in each row
           this.columnData.forEach(function(data, i) {
             const yPos = this.y(data.y) + this.y.bandwidth() / 2;
-            this._appendSvgText(this._svgGroup, this.columnWidth / 2, yPos, data.value);
+            this._appendSvgText(this._svgGroup, this.columnWidth / 2, yPos, data.value,
+              this.textColor, this.textSize);
           }.bind(this));
           // manually draw last (bottom) line
-          const yPos = this.y(exts.y[0]) + this.y.bandwidth();
-          this._appendSvgLine(this._svgGroup, 0, this.columnWidth,
-            yPos, yPos, this.borderColor, this.borderWidth);
+          let yPos = this.y(exts.y[0]) + this.y.bandwidth();
+          this._appendSvgLine(this._svgGroup, 0, this.columnWidth, yPos, yPos);
+          // draw column label
+          if (this.columnLabel) {
+            yPos = this.y(exts.y[0]) + this.y.bandwidth() + this.columnLabelSpacing;
+            this._appendSvgText(this._svgGroup, this.columnWidth / 2, yPos, this.columnLabel,
+              this.columnLabelTextColor, this.columnLabelTextSize);
+          }
         }, this.drawDebounceTime);
       },
 
@@ -139,31 +168,33 @@
           .attr('x2', x2)
           .attr('y1', y1)
           .attr('y2', y2)
-          .style('stroke', stroke)
-          .style('stroke-width', strokeWidth);
+          .style('stroke', this.borderColor)
+          .style('stroke-width', this.borderWidth);
       },
 
-      _appendSvgText: function(svg, x, y, text) {
+      _appendSvgText: function(svg, x, y, text, textColor, textSize) {
         svg.append('text')
           .attr('x', x)
           .attr('y', y)
           .text(text)
           .attr('text-anchor', 'middle')
           .attr('alignment-baseline', 'middle')
-          .attr('font-size', this.cellTextSize);
+          .attr('font-size', textSize)
+          .attr('fill', textColor);
       },
 
       _resolveCssVars: function() {
-        // TODO:
+        // TODO: resolve css vars for custom column
         this.debounce('resolve-css-vars', function() {
           // get series config obj
           const seriesConfig = this.completeSeriesConfig || {};
           const config = seriesConfig[this.seriesKey] || {};
           // resolve all css vars
-          // this.borderColor = config.legendBorderColor
-          //   || this._checkThemeVariable('--px-vis-heatmap-custom-column-border-color', '#FFF');
-          // this.borderWidth = config.legendBorderWidth
-          //   || this._checkThemeVariable('--px-vis-heatmap-custom-column-border-width', '0');
+          this.columnLabelTextColor = config.columnLabelTextColor
+            || this._checkThemeVariable('--px-vis-axis-color', 'black');
+          // TODO: sync this size with the axis size
+          this.columnLabelTextSize = config.columnLabelTextColor
+            || this._checkThemeVariable('', '12px');
           // // notify children
           // this.$.yAxis.updateStyles();
           // notify that style vars have changed

--- a/px-vis-heatmap-custom-column.html
+++ b/px-vis-heatmap-custom-column.html
@@ -1,0 +1,176 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../px-vis/px-vis-scale.html">
+<link rel="import" href="../px-vis/px-vis-svg.html">
+
+<link rel="import" href="../px-vis/px-vis-behavior-colors.html">
+<link rel="import" href="../px-vis/px-vis-behavior-common.html">
+<link rel="import" href="../px-vis/px-vis-behavior-chart.html">
+
+
+<dom-module id="px-vis-heatmap-custom-column">
+  <template>
+
+  </template>
+  <script>
+    Polymer({
+
+      is: 'px-vis-heatmap-custom-column',
+
+      behaviors: [
+        PxVisBehavior.baseSize,
+        PxVisBehavior.chartExtents,
+        PxVisBehavior.commonMethods,
+        PxVisBehavior.completeSeriesConfig,
+        PxVisBehavior.dataExtents,
+        PxVisBehavior.margins,
+        PxVisBehavior.observerCheck,
+        PxVisBehavior.svgDefinition,
+        PxVisBehavior.updateStylesOverride,
+        PxVisBehaviorD3.domainUpdate,
+        PxVisBehaviorChart.subConfiguration
+      ],
+
+      properties: {
+
+        columnData: {
+          type: Array
+        },
+
+        columnName: {
+          type: String,
+        },
+
+        columnWidth: {
+          type: Number,
+          value: 100
+        },
+
+        /**
+         * Color of border surrounding legend. Set by series config or css var.
+         */
+        borderColor: {
+          type: String,
+          value: 'black'
+        },
+
+        /**
+         * Width of border surrounding legend. Set by series config or css var.
+         */
+        borderWidth: {
+          type: String,
+          value: '1px'
+        },
+
+        /**
+         * Debounce time before drawing.
+         */
+        drawDebounceTime: {
+          type: Number,
+          value: 100
+        },
+
+        /**
+         * Observe changes to this in order to know when css vars have changed.
+         */
+        _stylesResolved: {
+          type: Boolean,
+          value: false
+        },
+
+        _svgGroup: {
+          type: Object
+        }
+
+      },
+
+      observers: [
+        '_drawElement(columnWidth, columnData.*, columnName, borderColor, borderWidth, margin.*, x, y, domainChanged, completeSeriesConfig, seriesKey, _stylesResolved)',
+      ],
+
+      detached: function() {
+        // remove gradient and rectangle drawings
+        if (!this._isObjEmpty(this._svgGroup)) {
+          this._svgGroup.remove();
+        }
+      },
+
+      _drawElement: function() {
+        const exts = this.chartExtents || this.dataExtents;
+        if (!exts || this.hasUndefinedArguments(arguments)) {
+          return;
+        }
+        this.debounce('custom-column-drawn-debounce', () => {
+          // remove prev column svg
+          if (!this._isObjEmpty(this._svgGroup)) {
+            this._svgGroup.remove();
+          }
+          // calculate position (using translate transform)
+          const xOffset = this.x(exts.x[exts.x.length - 1]) + this.x.bandwidth();
+          const yOffset = 0;
+          // xOffset maybe invalid if the x function is being updated
+          if (xOffset !== 0 && !xOffset) {
+            return;
+          }
+          const translate = 'translate(' + xOffset + ', ' + yOffset + ')';
+          // create svg group for this column
+          this._svgGroup = this.svg.append('g')
+            .attr('transform', translate);
+          // draw row lines in column
+          exts.y.forEach(function(yVal, i) {
+            const yPos = this.y(yVal);
+            this._appendSvgLine(this._svgGroup, 0, this.columnWidth,
+              yPos, yPos, this.borderColor, this.borderWidth);
+          }.bind(this));
+          // draw values in each row
+          this.columnData.forEach(function(data, i) {
+            const yPos = this.y(data.y) + this.y.bandwidth() / 2;
+            this._appendSvgText(this._svgGroup, this.columnWidth / 2, yPos, data.value);
+          }.bind(this));
+          // manually draw last (bottom) line
+          const yPos = this.y(exts.y[0]) + this.y.bandwidth();
+          this._appendSvgLine(this._svgGroup, 0, this.columnWidth,
+            yPos, yPos, this.borderColor, this.borderWidth);
+        }, this.drawDebounceTime);
+      },
+
+      _appendSvgLine: function(svg, x1, x2, y1, y2, stroke, strokeWidth) {
+        svg.append('line')
+          .attr('x1', x1)
+          .attr('x2', x2)
+          .attr('y1', y1)
+          .attr('y2', y2)
+          .style('stroke', stroke)
+          .style('stroke-width', strokeWidth);
+      },
+
+      _appendSvgText: function(svg, x, y, text) {
+        svg.append('text')
+          .attr('x', x)
+          .attr('y', y)
+          .text(text)
+          .attr('text-anchor', 'middle')
+          .attr('alignment-baseline', 'middle')
+          .attr('font-size', this.cellTextSize);
+      },
+
+      _resolveCssVars: function() {
+        // TODO:
+        this.debounce('resolve-css-vars', function() {
+          // get series config obj
+          const seriesConfig = this.completeSeriesConfig || {};
+          const config = seriesConfig[this.seriesKey] || {};
+          // resolve all css vars
+          // this.borderColor = config.legendBorderColor
+          //   || this._checkThemeVariable('--px-vis-heatmap-custom-column-border-color', '#FFF');
+          // this.borderWidth = config.legendBorderWidth
+          //   || this._checkThemeVariable('--px-vis-heatmap-custom-column-border-width', '0');
+          // // notify children
+          // this.$.yAxis.updateStyles();
+          // notify that style vars have changed
+          this.set('_stylesResolved', !this._stylesResolved);
+        }.bind(this), 10);
+      }
+
+    });
+  </script>
+</dom-module>

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -167,6 +167,7 @@
           chart-extents="[[chartExtents]]"
           data-extents="[[dataExtents]]"
           orientation="[[_legendOrientation]]"
+          gap-size="[[_legendGapSize]]"
           complete-series-config="[[completeSeriesConfig]]"
           domain-changed="[[domainChanged]]">
         </px-vis-heatmap-legend>
@@ -449,12 +450,22 @@
         _stylesResolved: {
           type: Boolean,
           value: false
+        },
+
+        _customColumnSvg: {
+          type: Object
+        },
+
+        _legendGapSize: {
+          type: Number,
+          value: 10
         }
 
       },
 
       observers: [
         '_drawCells(_internalMargin.*, chartData.*, showCellValue, x, y, domainChanged, completeSeriesConfig, seriesKey, _colorScale, _stylesResolved)',
+        '_drawCustomColumn(showCustomColumn, customColumnWidth, customColumnData.*, _internalMargin.*, x, y, domainChanged, completeSeriesConfig, seriesKey, _stylesResolved)',
         '_updateDataExtents(chartData, chartData.*, paddingOuter)',
         '_updateSeriesConfig(seriesConfig)',
         '_updateSeriesConfig(_colorsAreSet)',
@@ -462,6 +473,7 @@
         '_updateColorScale(chartData.*, colors.*, domainChanged)',
         '_updateInternalSize(squareMode, width, height, _internalMargin.*)',
         '_updateInternalMargin(showCustomColumn, margin.*)',
+        '_updateLegendGapSize(showCustomColumn, customColumnWidth)',
         '_xAxisConfigChanged(xAxisConfig)',
         '_yAxisConfigChanged(yAxisConfig)',
         '_legendConfigChanged(legendConfig)',
@@ -527,7 +539,60 @@
       },
 
       _drawCustomColumn: function() {
+        const exts = this.chartExtents || this.dataExtents;
+        if (!exts || this.hasUndefinedArguments(arguments)) {
+          return;
+        }
+        this.debounce('custom-column-drawn-debounce', () => {
+          // calculate position (using translate transform)
+          const xOffset = this.x(exts.x[exts.x.length - 1]) + this.x.bandwidth();
+          const yOffset = 0;
+          // xOffset maybe invalid if the x function is being updated
+          if (xOffset !== 0 && !xOffset) {
+            return;
+          }
+          const translate = 'translate(' + xOffset + ', ' + yOffset + ')';
+          // remove prev column svg
+          if (this._customColumnSvg) {
+            this._customColumnSvg.remove();
+          }
+          // create svg group for this column
+          this._customColumnSvg = this.svg.append('g')
+            .attr('transform', translate);
+          // draw each cell for column
+          exts.y.forEach(function(yVal, i) {
+            const yPos = this.y(yVal);
+            const textPos = yPos + this.y.bandwidth() / 2;
+            // draw line
+            this._appendSvgLine(this._customColumnSvg, 0, this.customColumnWidth,
+              yPos, yPos, this.cellBorderColor, this.cellBorderWidth);
+            // draw value
+            this._appendSvgText(this._customColumnSvg, this.customColumnWidth / 2, textPos, '50000');
+          }.bind(this));
+          // manually draw last (bottom) line
+          const yPos = this.y(exts.y[0]) + this.y.bandwidth();
+          this._appendSvgLine(this._customColumnSvg, 0, this.customColumnWidth,
+            yPos, yPos, this.cellBorderColor, this.cellBorderWidth);
+        }, this.drawDebounceTime);
+      },
 
+      _appendSvgLine: function(svg, x1, x2, y1, y2, stroke, strokeWidth) {
+        svg.append('line')
+          .attr('x1', x1)
+          .attr('x2', x2)
+          .attr('y1', y1)
+          .attr('y2', y2)
+          .style('stroke', stroke)
+          .style('stroke-width', strokeWidth);
+      },
+
+      _appendSvgText: function(svg, x, y, text) {
+        svg.append('text')
+          .attr('x', x)
+          .attr('y', y)
+          .text(text)
+          .attr('text-anchor', 'middle')
+          .attr('alignment-baseline', 'middle');
       },
 
       _collapseQueryIsValid: function(query) {
@@ -752,6 +817,18 @@
             cell: selectedCell
           });
         }
+      },
+
+      _updateLegendGapSize: function() {
+        if (this.hasUndefinedArguments(arguments)) {
+          console.log('error');
+          return;
+        }
+        let gapSize = 10;
+        if (this.showCustomColumn) {
+          gapSize += this.customColumnWidth;
+        }
+        this.set('_legendGapSize', gapSize);
       },
 
       _xAxisConfigChanged: function(xAxisConfig) {

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -63,7 +63,7 @@
         class="canvas"
         width="[[_internalWidth]]"
         height="[[_internalHeight]]"
-        margin="[[margin]]"
+        margin="[[_internalMargin]]"
         svg="{{svg}}"
         canvas-context="{{canvasContext}}"
         px-svg-elem="{{pxSvgElem}}">
@@ -73,7 +73,7 @@
         class="canvas"
         width="[[_internalWidth]]"
         height="[[_internalHeight]]"
-        margin="[[margin]]"
+        margin="[[_internalMargin]]"
         canvas-context="{{overlayCanvasContext}}">
       </px-vis-canvas>
       <!-- scale -->
@@ -86,7 +86,7 @@
         data-extents="[[dataExtents]]"
         width="[[_internalWidth]]"
         height="[[_internalHeight]]"
-        margin="[[margin]]"
+        margin="[[_internalMargin]]"
         chart-data="[[chartData]]"
         x="{{x}}"
         y="{{y}}"
@@ -99,7 +99,7 @@
         svg="[[layer.1]]"
         axis="[[y]]"
         axis-type="[[yAxisType]]"
-        margin="[[margin]]"
+        margin="[[_internalMargin]]"
         width="[[_internalWidth]]"
         height="[[_internalHeight]]"
         orientation="left"
@@ -117,7 +117,7 @@
         svg="[[layer.1]]"
         axis="[[x]]"
         axis-type="[[xAxisType]]"
-        margin="[[margin]]"
+        margin="[[_internalMargin]]"
         width="[[_internalWidth]]"
         height="[[_internalHeight]]"
         orientation="bottom"
@@ -160,7 +160,7 @@
           svg="[[svg]]"
           x="[[x]]"
           y="[[y]]"
-          margin="[[margin]]"
+          margin="[[_internalMargin]]"
           width="[[_internalWidth]]"
           height="[[_internalHeight]]"
           color-scale="[[_colorScale]]"
@@ -262,6 +262,24 @@
               'left': 50
             };
           }
+        },
+
+        /**
+         * Toggles an additional column at the end of the cells. Custom columns
+         * are defined by the customColumnData property.
+         */
+        showCustomColumn: {
+          type: Boolean,
+          value: false
+        },
+
+        customColumnData: {
+          type: Object
+        },
+
+        customColumnWidth: {
+          type: Number,
+          value: 100
         },
 
         /**
@@ -421,6 +439,10 @@
           type: Number
         },
 
+        _internalMargin: {
+          type: Object
+        },
+
         /**
          * Observe changes to this in order to know when css vars have changed.
          */
@@ -432,13 +454,14 @@
       },
 
       observers: [
-        '_drawCells(margin, chartData.*, showCellValue, x, y, domainChanged, completeSeriesConfig, seriesKey, _colorScale, _stylesResolved)',
+        '_drawCells(_internalMargin.*, chartData.*, showCellValue, x, y, domainChanged, completeSeriesConfig, seriesKey, _colorScale, _stylesResolved)',
         '_updateDataExtents(chartData, chartData.*, paddingOuter)',
         '_updateSeriesConfig(seriesConfig)',
         '_updateSeriesConfig(_colorsAreSet)',
         '_updateSeriesKey(seriesKey)',
         '_updateColorScale(chartData.*, colors.*, domainChanged)',
-        '_updateInternalSize(squareMode, width, height, margin.*)',
+        '_updateInternalSize(squareMode, width, height, _internalMargin.*)',
+        '_updateInternalMargin(showCustomColumn, margin.*)',
         '_xAxisConfigChanged(xAxisConfig)',
         '_yAxisConfigChanged(yAxisConfig)',
         '_legendConfigChanged(legendConfig)',
@@ -503,7 +526,11 @@
         }
       },
 
-      _collapseQueryIsValid(query) {
+      _drawCustomColumn: function() {
+
+      },
+
+      _collapseQueryIsValid: function(query) {
         if (typeof query === 'number') {
           return true;
         }
@@ -513,7 +540,7 @@
         return false;
       },
 
-      _getCollapseQuery(collapseAt) {
+      _getCollapseQuery: function(collapseAt) {
         if (typeof collapseAt === 'number') {
           return collapseAt + 'px';
         }
@@ -522,7 +549,7 @@
         }
       },
 
-      _collapsedChanged() {
+      _collapsedChanged: function() {
         this.set('_legendOrientation', this.collapsed ? 'bottom' : 'right');
       },
 
@@ -678,6 +705,23 @@
           }
         }
         return height;
+      },
+
+      _updateInternalMargin: function() {
+        if (this.hasUndefinedArguments(arguments)) {
+          return;
+        }
+        const margin = {
+          top: this.margin.top,
+          bottom: this.margin.bottom,
+          left: this.margin.left,
+          right: this.margin.right
+        };
+        // add additional margin for custom column
+        if (this.showCustomColumn) {
+          margin.right += this.customColumnWidth;
+        }
+        this.set('_internalMargin', margin);
       },
 
       _selectedCellChanged: function(selectedCell, prevSelectedCell) {

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -12,6 +12,7 @@
 
 <link rel="import" href="px-vis-heatmap-cell.html">
 <link rel="import" href="px-vis-heatmap-legend.html">
+<link rel="import" href="px-vis-heatmap-custom-column.html">
 
 <!-- <link rel="import" href="../px-vis/css/px-vis-styles.html"> -->
 <link rel="import" href="css/px-vis-heatmap-styles.html">
@@ -154,6 +155,24 @@
         </px-vis-heatmap-cell>
       </template> -->
 
+      <template is="dom-if" if="[[showCustomColumn]]" restamp>
+        <px-vis-heatmap-custom-column
+          border-color="[[cellBorderColor]]"
+          border-width="[[cellBorderWidth]]"
+          svg="[[svg]]"
+          x="[[x]]"
+          y="[[y]]"
+          margin="[[_internalMargin]]"
+          width="[[_internalWidth]]"
+          height="[[_internalHeight]]"
+          chart-extents="[[chartExtents]]"
+          data-extents="[[dataExtents]]"
+          complete-series-config="[[completeSeriesConfig]]"
+          series-key="[[seriesKey]]"
+          domain-changed="[[domainChanged]]">
+        </px-vis-heatmap-custom-column>
+      </template>
+
       <template is="dom-if" if="[[showLegend]]" restamp>
         <px-vis-heatmap-legend
           id="legend"
@@ -274,13 +293,8 @@
           value: false
         },
 
-        customColumnData: {
+        customColumnConfig: {
           type: Object
-        },
-
-        customColumnWidth: {
-          type: Number,
-          value: 100
         },
 
         /**
@@ -441,7 +455,8 @@
         },
 
         _internalMargin: {
-          type: Object
+          type: Object,
+          value: {}
         },
 
         /**
@@ -450,10 +465,6 @@
         _stylesResolved: {
           type: Boolean,
           value: false
-        },
-
-        _customColumnSvg: {
-          type: Object
         },
 
         _legendGapSize: {
@@ -465,18 +476,18 @@
 
       observers: [
         '_drawCells(_internalMargin.*, chartData.*, showCellValue, x, y, domainChanged, completeSeriesConfig, seriesKey, _colorScale, _stylesResolved)',
-        '_drawCustomColumn(showCustomColumn, customColumnWidth, customColumnData.*, _internalMargin.*, x, y, domainChanged, completeSeriesConfig, seriesKey, _stylesResolved)',
         '_updateDataExtents(chartData, chartData.*, paddingOuter)',
         '_updateSeriesConfig(seriesConfig)',
         '_updateSeriesConfig(_colorsAreSet)',
         '_updateSeriesKey(seriesKey)',
         '_updateColorScale(chartData.*, colors.*, domainChanged)',
         '_updateInternalSize(squareMode, width, height, _internalMargin.*)',
-        '_updateInternalMargin(showCustomColumn, margin.*)',
-        '_updateLegendGapSize(showCustomColumn, customColumnWidth)',
+        '_updateInternalMargin(showCustomColumn, customColumnConfig, margin.*)',
+        '_updateLegendGapSize(showCustomColumn, customColumnConfig.*)',
         '_xAxisConfigChanged(xAxisConfig)',
         '_yAxisConfigChanged(yAxisConfig)',
-        '_legendConfigChanged(legendConfig)',
+        '_legendConfigChanged(showLegend, legendConfig)',
+        '_customColumnConfigChanged(showCustomColumn, customColumnConfig)',
         '_resolveCssVars(_stylesUpdated)'
       ],
 
@@ -536,63 +547,6 @@
           canvasContext.textBaseline = 'middle';
           canvasContext.fillText(cellData.value, xPos, yPos, this.x.bandwidth());
         }
-      },
-
-      _drawCustomColumn: function() {
-        const exts = this.chartExtents || this.dataExtents;
-        if (!exts || this.hasUndefinedArguments(arguments)) {
-          return;
-        }
-        this.debounce('custom-column-drawn-debounce', () => {
-          // calculate position (using translate transform)
-          const xOffset = this.x(exts.x[exts.x.length - 1]) + this.x.bandwidth();
-          const yOffset = 0;
-          // xOffset maybe invalid if the x function is being updated
-          if (xOffset !== 0 && !xOffset) {
-            return;
-          }
-          const translate = 'translate(' + xOffset + ', ' + yOffset + ')';
-          // remove prev column svg
-          if (this._customColumnSvg) {
-            this._customColumnSvg.remove();
-          }
-          // create svg group for this column
-          this._customColumnSvg = this.svg.append('g')
-            .attr('transform', translate);
-          // draw each cell for column
-          exts.y.forEach(function(yVal, i) {
-            const yPos = this.y(yVal);
-            const textPos = yPos + this.y.bandwidth() / 2;
-            // draw line
-            this._appendSvgLine(this._customColumnSvg, 0, this.customColumnWidth,
-              yPos, yPos, this.cellBorderColor, this.cellBorderWidth);
-            // draw value
-            this._appendSvgText(this._customColumnSvg, this.customColumnWidth / 2, textPos, '50000');
-          }.bind(this));
-          // manually draw last (bottom) line
-          const yPos = this.y(exts.y[0]) + this.y.bandwidth();
-          this._appendSvgLine(this._customColumnSvg, 0, this.customColumnWidth,
-            yPos, yPos, this.cellBorderColor, this.cellBorderWidth);
-        }, this.drawDebounceTime);
-      },
-
-      _appendSvgLine: function(svg, x1, x2, y1, y2, stroke, strokeWidth) {
-        svg.append('line')
-          .attr('x1', x1)
-          .attr('x2', x2)
-          .attr('y1', y1)
-          .attr('y2', y2)
-          .style('stroke', stroke)
-          .style('stroke-width', strokeWidth);
-      },
-
-      _appendSvgText: function(svg, x, y, text) {
-        svg.append('text')
-          .attr('x', x)
-          .attr('y', y)
-          .text(text)
-          .attr('text-anchor', 'middle')
-          .attr('alignment-baseline', 'middle');
       },
 
       _collapseQueryIsValid: function(query) {
@@ -776,17 +730,23 @@
         if (this.hasUndefinedArguments(arguments)) {
           return;
         }
-        const margin = {
-          top: this.margin.top,
-          bottom: this.margin.bottom,
-          left: this.margin.left,
-          right: this.margin.right
-        };
-        // add additional margin for custom column
-        if (this.showCustomColumn) {
-          margin.right += this.customColumnWidth;
-        }
-        this.set('_internalMargin', margin);
+        this.debounce('adsfasdfasdf', function() {
+          const margin = {
+            top: this.margin.top,
+            bottom: this.margin.bottom,
+            left: this.margin.left,
+            right: this.margin.right
+          };
+          // add additional margin for custom column
+          if (this.showCustomColumn) {
+            const customColumn = this._getCustomColumn();
+            if (customColumn) {
+              margin.right += customColumn.columnWidth;
+            }
+          }
+          this.set('_internalMargin', margin);
+        }.bind(this), 10);
+
       },
 
       _selectedCellChanged: function(selectedCell, prevSelectedCell) {
@@ -821,14 +781,18 @@
 
       _updateLegendGapSize: function() {
         if (this.hasUndefinedArguments(arguments)) {
-          console.log('error');
           return;
         }
-        let gapSize = 10;
-        if (this.showCustomColumn) {
-          gapSize += this.customColumnWidth;
-        }
-        this.set('_legendGapSize', gapSize);
+        this.debounce('update-legend-gap-size', function() {
+          let gapSize = 10;
+          if (this.showCustomColumn) {
+            const customColumn = this._getCustomColumn();
+            if (customColumn) {
+              gapSize += customColumn.columnWidth;
+            }
+          }
+          this.set('_legendGapSize', gapSize);
+        }.bind(this), 10);
       },
 
       _xAxisConfigChanged: function(xAxisConfig) {
@@ -845,20 +809,27 @@
         this._applyConfigToElement(yAxisConfig, this.$.yAxis);
       },
 
-      _legendConfigChanged: function(legendConfig) {
+      _legendConfigChanged: function(showLegend, legendConfig) {
         if (this.hasUndefinedArguments(arguments)) {
           return;
         }
         // debouncing because this gets called before dom-if that instantiates legend happens
         this.debounce('legend-config-changed', function() {
-          let legend;
-          if (this.shadowRoot) {
-            legend = this.shadowRoot.querySelector('px-vis-heatmap-legend');
-          } else {
-            legend = Polymer.dom(this.root).querySelector('px-vis-heatmap-legend');
-          }
+          const legend = this._getLegend();
           if (legend) {
             this._applyConfigToElement(legendConfig, legend);
+          }
+        }.bind(this), 10);
+      },
+
+      _customColumnConfigChanged: function(showCustomColumn, customColumnConfig) {
+        if (this.hasUndefinedArguments(arguments)) {
+          return;
+        }
+        this.debounce('custom-column-config-changed', function() {
+          const customColumn = this._getCustomColumn();
+          if (customColumn) {
+            this._applyConfigToElement(customColumnConfig, customColumn);
           }
         }.bind(this), 10);
       },
@@ -868,6 +839,14 @@
           return this.shadowRoot.querySelector('px-vis-heatmap-legend');
         } else {
           return Polymer.dom(this.root).querySelector('px-vis-heatmap-legend');
+        }
+      },
+
+      _getCustomColumn: function() {
+        if (this.shadowRoot) {
+          return this.shadowRoot.querySelector('px-vis-heatmap-custom-column');
+        } else {
+          return Polymer.dom(this.root).querySelector('px-vis-heatmap-custom-column');
         }
       },
 

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -296,7 +296,8 @@
         },
 
         customColumnConfig: {
-          type: Object
+          type: Object,
+          value: {}
         },
 
         /**
@@ -485,7 +486,7 @@
         '_updateColorScale(chartData.*, colors.*, domainChanged)',
         '_updateInternalSize(squareMode, width, height, _internalMargin.*)',
         '_updateInternalMargin(showCustomColumn, customColumnConfig, margin.*)',
-        '_updateLegendGapSize(showCustomColumn, customColumnConfig.*)',
+        '_updateLegendGapSize(showCustomColumn, customColumnConfig.*, _legendOrientation)',
         '_xAxisConfigChanged(xAxisConfig)',
         '_yAxisConfigChanged(yAxisConfig)',
         '_legendConfigChanged(showLegend, legendConfig)',
@@ -732,7 +733,7 @@
         if (this.hasUndefinedArguments(arguments)) {
           return;
         }
-        this.debounce('adsfasdfasdf', function() {
+        this.debounce('update-internal-margin', function() {
           const margin = {
             top: this.margin.top,
             bottom: this.margin.bottom,
@@ -742,13 +743,12 @@
           // add additional margin for custom column
           if (this.showCustomColumn) {
             const customColumn = this._getCustomColumn();
-            if (customColumn) {
+            if (customColumn && customColumn.columnWidth) {
               margin.right += customColumn.columnWidth;
             }
           }
           this.set('_internalMargin', margin);
         }.bind(this), 10);
-
       },
 
       _selectedCellChanged: function(selectedCell, prevSelectedCell) {
@@ -786,8 +786,8 @@
           return;
         }
         this.debounce('update-legend-gap-size', function() {
-          let gapSize = 10;
-          if (this.showCustomColumn) {
+          let gapSize = 20;
+          if (this.showCustomColumn && this._legendOrientation !== 'bottom') {
             const customColumn = this._getCustomColumn();
             if (customColumn) {
               gapSize += customColumn.columnWidth;

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -159,6 +159,8 @@
         <px-vis-heatmap-custom-column
           border-color="[[cellBorderColor]]"
           border-width="[[cellBorderWidth]]"
+          text-size="[[cellTextSize]]"
+          text-color="[[cellTextColor]]"
           svg="[[svg]]"
           x="[[x]]"
           y="[[y]]"
@@ -965,6 +967,10 @@
           const legend = this._getLegend();
           if (legend) {
             legend.updateStyles();
+          }
+          const customColumn = this._getCustomColumn();
+          if (customColumn) {
+            customColumn.updateStyles();
           }
           // notify that style vars have changed
           this.set('_stylesResolved', !this._stylesResolved);

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -295,6 +295,30 @@
           value: false
         },
 
+        /**
+         * Sets the configuration and data for the custom column.
+         * This object defines all aspects of the column including labe,
+         * width, and the data.
+         *
+         * Example of customColumnConfig object:
+         *
+         * {
+         *   columnLabel: 'Accuracy',
+         *   columnWidth: 75,
+         *   columnData: [{
+         *     y: 'Asset 1',
+         *     value: 10
+         *   },
+         *   {
+         *     y: 'Asset 2',
+         *     value: 20
+         *   },
+         *   {
+         *     y: 'Asset 3',
+         *     value: 30
+         *   }]
+         *  }
+         */
         customColumnConfig: {
           type: Object,
           value: {}


### PR DESCRIPTION
Adding ability to specify a custom column which gets appended to the far right of the heatmap.  This column is modeled after the accuracy column in a confusion matrix.  The application much set all the details of this column.  

Two new properties are exposed on the heatmap:
 * ```showCustomColumn```: boolean that toggles visibility of custom column
 * ```customColumnConfig```: config object for custom column which also includes the data

Example of customColumnConfig item:

```
      customColumnConfig: {
        type: Object,
        inputType: 'code:JSON',
        defaultValue: {
          columnLabel: 'Accuracy',
          columnWidth: 75,
          columnData: [
            {
              y: 'Asset 1',
              value: 10
            },
            {
              y: 'Asset 2',
              value: 20
            },
            {
              y: 'Asset 3',
              value: 30
            }
          ]
        }
      }
```