### PR TITLE
Adding seriesConfig value mapping

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "PxVisBehavior": false,
     "PxVisBehaviorChart": false,
     "PxVisBehaviorD3": false,
+    "PxBehaviorHeatmap": false,
     "Vaadin": false
   },
   "rules": {

--- a/demo/px-vis-heatmap-demo.html
+++ b/demo/px-vis-heatmap-demo.html
@@ -210,49 +210,49 @@
         inputType: 'code:JSON',
         defaultValue: [
           {
-            x: '1:00',
-            y: 'Asset 1',
-            value: 0
+            time: '1:00',
+            asset: 'Asset 1',
+            temp: 0
           },
           {
-            x: '1:00',
-            y: 'Asset 2',
-            value: 10
+            time: '1:00',
+            asset: 'Asset 2',
+            temp: 10
           },
           {
-            x: '1:00',
-            y: 'Asset 3',
-            value: 20
+            time: '1:00',
+            asset: 'Asset 3',
+            temp: 20
           },
           {
-            x: '2:00',
-            y: 'Asset 1',
-            value: 30
+            time: '2:00',
+            asset: 'Asset 1',
+            temp: 30
           },
           {
-            x: '2:00',
-            y: 'Asset 2',
-            value: 40
+            time: '2:00',
+            asset: 'Asset 2',
+            temp: 40
           },
           {
-            x: '2:00',
-            y: 'Asset 3',
-            value: 50
+            time: '2:00',
+            asset: 'Asset 3',
+            temp: 50
           },
           {
-            x: '3:00',
-            y: 'Asset 1',
-            value: 65
+            time: '3:00',
+            asset: 'Asset 1',
+            temp: 65
           },
           {
-            x: '3:00',
-            y: 'Asset 2',
-            value: 75
+            time: '3:00',
+            asset: 'Asset 2',
+            temp: 75
           },
           {
-            x: '3:00',
-            y: 'Asset 3',
-            value: 100
+            time: '3:00',
+            asset: 'Asset 3',
+            temp: 100
           }
         ]
       },
@@ -261,9 +261,9 @@
         type: Object,
         inputType: 'code:JSON',
         defaultValue: {
-          x: ['1:00', '2:00', '3:00'],
-          y: ['Asset 1', 'Asset 2', 'Asset 3'],
-          value: [0, 100]
+          time: ['1:00', '2:00', '3:00'],
+          asset: ['Asset 1', 'Asset 2', 'Asset 3'],
+          temp: [0, 100]
         }
       },
 
@@ -273,9 +273,9 @@
         defaultValue: {
           'series1': {
             'name': 'Series 1',
-            'x': 'x',
-            'y': 'y',
-            'value': 'value'
+            'x': 'time',
+            'y': 'asset',
+            'value': 'temp'
           }
         }
       },
@@ -426,9 +426,9 @@
             // increase values in a diaganol pattern
             const power = x === y ? 1 : (x + y) / (xSize + ySize - 2);
             data.push({
-              x: x + ':00',
-              y: 'Asset ' + y,
-              value: Math.round(100 * power)
+              time: x + ':00',
+              asset: 'Asset ' + y,
+              temp: Math.round(100 * power)
             });
           }
         }
@@ -453,9 +453,9 @@
             // increase values in a diaganol pattern
             const power = x === y ? 1 : (x + y) / (xSize + ySize - 2);
             data.push({
-              x: x + ':00',
-              y: 'Asset ' + y,
-              value: Math.round(100 * power)
+              time: x + ':00',
+              asset: 'Asset ' + y,
+              temp: Math.round(100 * power)
             });
           }
         }
@@ -470,9 +470,9 @@
           // increase values in a diaganol pattern
           const power = isGradient ? (x + y) / (xNum + yNum - 2) : Math.random();
           data.push({
-            x: x + ':00',
-            y: 'Asset ' + y,
-            value: Math.round(100 * power)
+            time: x + ':00',
+            asset: 'Asset ' + y,
+            temp: Math.round(100 * power)
           });
         }
       }
@@ -481,15 +481,15 @@
 
     _generateChartExtents: function(xNum, yNum) {
       const exts = {
-        x: [],
-        y: [],
-        value: [0, 100]
+        time: [],
+        asset: [],
+        temp: [0, 100]
       };
       for (let i = 0; i < xNum; i++) {
-        exts.x.push(i + ':00');
+        exts.time.push(i + ':00');
       }
       for (let i = 0; i < yNum; i++) {
-        exts.y.push('Asset ' + i);
+        exts.asset.push('Asset ' + i);
       }
       return exts;
     },
@@ -515,17 +515,17 @@
 
     _handleCellClick: function(e, details) {
       this.set('eventMessage', 'Cell clicked ('
-          + details.cell.x + ', ' + details.cell.y + ') [' + details.cell.value + ']');
+          + details.cell.time + ', ' + details.cell.asset + ') [' + details.cell.temp + ']');
     },
 
     _handleCellMouseover: function(e, details) {
       this.set('eventMessage', 'Cell mouseover ('
-          + details.cell.x + ', ' + details.cell.y + ') [' + details.cell.value + ']');
+          + details.cell.time + ', ' + details.cell.asset + ') [' + details.cell.temp + ']');
     },
 
     _handleCellMouseout: function(e, details) {
       this.set('eventMessage', 'Cell mouseout ('
-          + details.cell.x + ', ' + details.cell.y + ') [' + details.cell.value + ']');
+          + details.cell.time + ', ' + details.cell.asset + ') [' + details.cell.temp + ']');
     },
 
     _export: function() {

--- a/px-heatmap-behavior.html
+++ b/px-heatmap-behavior.html
@@ -1,0 +1,43 @@
+<script>
+var PxBehaviorHeatmap = window.PxBehaviorHeatmap = (window.PxBehaviorHeatmap || {});
+
+/*
+    Name:
+    PxBehaviorHeatmap.normalizeObjects
+
+    Description:
+    Behavior providing a convenience function for normalizing objects
+    an expected format using the completeSeriesConfig object.
+
+    @polymerBehavior PxBehaviorHeatmap.normalizeObjects
+*/
+PxBehaviorHeatmap.normalizeObjects = {
+
+  /**
+   * Convenience method for applying completeSeriesConfig keys to a
+   * chartData item and returning an object with standard
+   * heatmap data keys (x, y, and value).
+   */
+  _normalizeChartDataItem: function(dataItem) {
+    return {
+      x: dataItem[this.completeSeriesConfig[this.seriesKey].x],
+      y: dataItem[this.completeSeriesConfig[this.seriesKey].y],
+      value: dataItem[this.completeSeriesConfig[this.seriesKey].value]
+    };
+  },
+
+  /**
+   * Convenience method for applying completeSeriesConfig keys to a
+   * extents item (dataExtents or chartExtents) and returning an object with standard
+   * heatmap data keys (x, y, and value).
+   */
+  _normalizeExtentsObj: function(exts) {
+    return {
+      x: exts[this.completeSeriesConfig[this.seriesKey].x],
+      y: exts[this.completeSeriesConfig[this.seriesKey].y],
+      value: exts[this.completeSeriesConfig[this.seriesKey].value]
+    };
+  }
+
+};
+</script>

--- a/px-vis-heatmap-custom-column.html
+++ b/px-vis-heatmap-custom-column.html
@@ -6,6 +6,8 @@
 <link rel="import" href="../px-vis/px-vis-behavior-common.html">
 <link rel="import" href="../px-vis/px-vis-behavior-chart.html">
 
+<link rel="import" href="px-heatmap-behavior.html">
+
 
 <dom-module id="px-vis-heatmap-custom-column">
   <template>
@@ -27,7 +29,8 @@
         PxVisBehavior.svgDefinition,
         PxVisBehavior.updateStylesOverride,
         PxVisBehaviorD3.domainUpdate,
-        PxVisBehaviorChart.subConfiguration
+        PxVisBehaviorChart.subConfiguration,
+        PxBehaviorHeatmap.normalizeObjects
       ],
 
       properties: {
@@ -119,10 +122,11 @@
       },
 
       _drawElement: function() {
-        const exts = this.chartExtents || this.dataExtents;
+        let exts = this.chartExtents || this.dataExtents;
         if (!exts || this.hasUndefinedArguments(arguments)) {
           return;
         }
+        exts = this._normalizeExtentsObj(exts);
         this.debounce('custom-column-drawn-debounce', () => {
           // remove prev column svg
           if (!this._isObjEmpty(this._svgGroup)) {

--- a/px-vis-heatmap-legend.html
+++ b/px-vis-heatmap-legend.html
@@ -7,6 +7,8 @@
 <link rel="import" href="../px-vis/px-vis-behavior-common.html">
 <link rel="import" href="../px-vis/px-vis-behavior-chart.html">
 
+<link rel="import" href="px-heatmap-behavior.html">
+
 
 <dom-module id="px-vis-heatmap-legend">
   <template>
@@ -63,7 +65,8 @@
         PxVisBehavior.updateStylesOverride,
         PxVisBehaviorD3.domainUpdate,
         PxVisBehaviorChart.axisConfigs,
-        PxVisBehaviorChart.subConfiguration
+        PxVisBehaviorChart.subConfiguration,
+        PxBehaviorHeatmap.normalizeObjects
       ],
 
       properties: {
@@ -308,10 +311,11 @@
       },
 
       _updateRectangePosition: function() {
-        const exts = this.chartExtents || this.dataExtents;
+        let exts = this.chartExtents || this.dataExtents;
         if (!exts || this.hasUndefinedArguments(arguments)) {
           return;
         }
+        exts = this._normalizeExtentsObj(exts);
 
         let height;
         let xOffset;

--- a/px-vis-heatmap.html
+++ b/px-vis-heatmap.html
@@ -10,6 +10,8 @@
 <link rel="import" href="../px-vis/px-vis-behavior-chart.html">
 <link rel="import" href="../px-vis/px-vis-behavior-d3.html">
 
+<link rel="import" href="px-heatmap-behavior.html">
+
 <link rel="import" href="px-vis-heatmap-cell.html">
 <link rel="import" href="px-vis-heatmap-legend.html">
 <link rel="import" href="px-vis-heatmap-custom-column.html">
@@ -190,6 +192,7 @@
           orientation="[[_legendOrientation]]"
           gap-size="[[_legendGapSize]]"
           complete-series-config="[[completeSeriesConfig]]"
+          series-key="[[seriesKey]]"
           domain-changed="[[domainChanged]]">
         </px-vis-heatmap-legend>
       </template>
@@ -232,7 +235,8 @@
         PxVisBehaviorChart.saveImage,
         PxVisBehaviorChart.subConfiguration,
         PxVisBehaviorD3.canvasContext,
-        PxVisBehaviorD3.svgLower
+        PxVisBehaviorD3.svgLower,
+        PxBehaviorHeatmap.normalizeObjects
       ],
 
       properties: {
@@ -503,11 +507,10 @@
 
       observers: [
         '_drawCells(_internalMargin.*, chartData.*, showCellValue, x, y, domainChanged, completeSeriesConfig, seriesKey, _colorScale, _stylesResolved)',
-        '_updateDataExtents(chartData, chartData.*, paddingOuter)',
+        '_updateDataExtents(chartData, chartData.*, paddingOuter, completeSeriesConfig, seriesKey)',
         '_updateSeriesConfig(seriesConfig)',
         '_updateSeriesConfig(_colorsAreSet)',
-        '_updateSeriesKey(seriesKey)',
-        '_updateColorScale(chartData.*, colors.*, domainChanged)',
+        '_updateColorScale(chartData.*, colors.*, domainChanged, completeSeriesConfig, seriesKey)',
         '_updateInternalSize(squareMode, width, height, _internalMargin.*)',
         '_updateInternalMargin(showCustomColumn, customColumnConfig, margin.*)',
         '_updateLegendGapSize(showCustomColumn, customColumnConfig.*, _legendOrientation)',
@@ -551,11 +554,13 @@
       },
 
       _drawCell: function(canvasContext, cellData) {
+        const data = this._normalizeChartDataItem(cellData);
         const borderWidth = parseFloat(this.cellBorderWidth.replace('px', ''));
         // draw and fill rectangle
         canvasContext.beginPath();
-        canvasContext.rect(this.x(cellData.x), this.y(cellData.y), this.x.bandwidth(), this.y.bandwidth());
-        canvasContext.fillStyle = this._colorScale(cellData.value);
+        canvasContext.rect(this.x(data.x),
+          this.y(data.y), this.x.bandwidth(), this.y.bandwidth());
+        canvasContext.fillStyle = this._colorScale(data.value);
         canvasContext.fill();
         // draw border
         if (!isNaN(borderWidth) && borderWidth > 0) {
@@ -565,14 +570,14 @@
         }
         // draw value if needed
         if (this.showCellValue) {
-          const xPos = this.x(cellData.x) + this.x.bandwidth() / 2;
-          const yPos = this.y(cellData.y) + this.y.bandwidth() / 2;
+          const xPos = this.x(data.x) + this.x.bandwidth() / 2;
+          const yPos = this.y(data.y) + this.y.bandwidth() / 2;
           canvasContext.beginPath();
           canvasContext.font = this.cellTextSize + ' Arial';
           canvasContext.fillStyle = this.cellTextColor;
           canvasContext.textAlign = 'center';
           canvasContext.textBaseline = 'middle';
-          canvasContext.fillText(cellData.value, xPos, yPos, this.x.bandwidth());
+          canvasContext.fillText(data.value, xPos, yPos, this.x.bandwidth());
         }
       },
 
@@ -612,14 +617,16 @@
       },
 
       _updateDataExtents: function() {
-        if (!this.chartData || !this.x || !this.y) {
+        if (!this.chartData || !this.x || !this.y || !this.completeSeriesConfig || !this.seriesKey) {
           return;
         }
-        this.dataExtents = this._calcExtents(this.chartData);
-        if (this.x && this.y) {
-          this.x.paddingOuter(this.paddingOuter);
-          this.y.paddingOuter(this.paddingOuter);
-        }
+        this.debounce('update-data-extents', function() {
+          this.dataExtents = this._calcExtents(this.chartData);
+          if (this.x && this.y) {
+            this.x.paddingOuter(this.paddingOuter);
+            this.y.paddingOuter(this.paddingOuter);
+          }
+        }.bind(this), 10);
       },
 
       /**
@@ -627,20 +634,22 @@
        * values found in the chart data.
        */
       _calcExtents: function(chartData) {
-        const exts = {
-          x: [],
-          y: [],
-          value: [Infinity, -Infinity]
-        };
-        chartData.forEach((data) => {
-          if (exts.x.indexOf(data.x) < 0) {
-            exts.x.push(data.x);
+        const exts = {};
+        exts[this.completeSeriesConfig[this.seriesKey].x] = [];
+        exts[this.completeSeriesConfig[this.seriesKey].y] = [];
+        exts[this.completeSeriesConfig[this.seriesKey].value] = [Infinity, -Infinity];
+        chartData.forEach((cellData) => {
+          const data = this._normalizeChartDataItem(cellData);
+          if (exts[this.completeSeriesConfig[this.seriesKey].x].indexOf(data.x) < 0) {
+            exts[this.completeSeriesConfig[this.seriesKey].x].push(data.x);
           }
-          if (exts.y.indexOf(data.y) < 0) {
-            exts.y.push(data.y);
+          if (exts[this.completeSeriesConfig[this.seriesKey].y].indexOf(data.y) < 0) {
+            exts[this.completeSeriesConfig[this.seriesKey].y].push(data.y);
           }
-          exts.value[0] = Math.min(exts.value[0], data.value);
-          exts.value[1] = Math.max(exts.value[1], data.value);
+          exts[this.completeSeriesConfig[this.seriesKey].value][0]
+            = Math.min(exts[this.completeSeriesConfig[this.seriesKey].value][0], data.value);
+          exts[this.completeSeriesConfig[this.seriesKey].value][1]
+            = Math.max(exts[this.completeSeriesConfig[this.seriesKey].value][1], data.value);
         });
         return exts;
       },
@@ -679,42 +688,26 @@
         }, 10);
       },
 
-      _updateSeriesKey: function() {
+      _updateColorScale: function() {
         if (this.hasUndefinedArguments(arguments)) {
           return;
         }
-        let cells;
-        if (this.shadowRoot) {
-          cells = this.shadowRoot.querySelectorAll('px-vis-heatmap-cell');
-        } else {
-          cells = Polymer.dom(this.root).querySelectorAll('px-vis-heatmap-cell');
-        }
-        cells.forEach((cell) => cell.seriesKey = this.seriesKey);
-      },
-
-      _updateColorScale: function() {
-        if (!this.dataExtents && !this.chartExtents) {
-          return;
-        }
-        if (!this.colors || this.colors.length < 1) {
-          return;
-        }
-        // get chart min and max values
-        const exts = this.chartExtents || this.dataExtents;
-        if (!exts.value) {
-          return;
-        }
-        // calculate the value threshold for each color
-        const valueThresholds = [];
-        const rangePerColor = (exts.value[1] - exts.value[0]) / (this.colors.length - 1);
-        for (let i = 0; i < this.colors.length; i++) {
-          valueThresholds.push(exts.value[0] + rangePerColor * i);
-        }
-        // in case of rounding limitations, manually set last value to our max
-        valueThresholds[valueThresholds.length - 1] = exts.value[1];
-        this.set('_colorScale', Px.d3.scaleLinear()
-          .domain(valueThresholds)
-          .range(this.colors));
+        this.debounce('update-color-scale', function() {
+          // get chart min and max values
+          let exts = this.chartExtents || this.dataExtents;
+          exts = this._normalizeExtentsObj(exts);
+          // calculate the value threshold for each color
+          const valueThresholds = [];
+          const rangePerColor = (exts.value[1] - exts.value[0]) / (this.colors.length - 1);
+          for (let i = 0; i < this.colors.length; i++) {
+            valueThresholds.push(exts.value[0] + rangePerColor * i);
+          }
+          // in case of rounding limitations, manually set last value to our max
+          valueThresholds[valueThresholds.length - 1] = exts.value[1];
+          this.set('_colorScale', Px.d3.scaleLinear()
+            .domain(valueThresholds)
+            .range(this.colors));
+        }.bind(this), 10);
       },
 
       _updateInternalSize: function() {
@@ -922,9 +915,10 @@
        */
       _getCellByPosition: function(xPos, yPos) {
         let cell;
-        this.chartData.forEach((item) => {
-          if (item.x === xPos && item.y === yPos) {
-            cell = item;
+        this.chartData.forEach((cellData) => {
+          const data = this._normalizeChartDataItem(cellData);
+          if (data.x === xPos && data.y === yPos) {
+            cell = cellData;
           }
         });
         return cell;
@@ -943,11 +937,12 @@
         this._closeTooltip();
       },
 
-      _showTooltip: function(cell, msg) {
+      _showTooltip: function(cellData, msg) {
         const tooltipMarginBottom = -20;
+        const data = this._normalizeChartDataItem(cellData);
         // get absolute position for tooltip
-        const x = this.x(cell.x) + this.margin.left + this.x.bandwidth() / 2;
-        const y = this.y(cell.y) - tooltipMarginBottom;
+        const x = this.x(data.x) + this.margin.left + this.x.bandwidth() / 2;
+        const y = this.y(data.y) - tooltipMarginBottom;
         this.$.tooltipDiv.style.left = x + 'px';
         // this.$.tooltipDiv.style.left = 0;
         this.$.tooltipDiv.style.top = y + 'px';
@@ -960,12 +955,13 @@
         this.$.tooltip.opened = false;
       },
 
-      _createTooltipMessage: function(cell) {
+      _createTooltipMessage: function(cellData) {
+        const data = this._normalizeChartDataItem(cellData);
         let msg = '<h1 style="text-weight:bold;font-size:125%;">';
-        msg += 'Asset ' + cell.x + ', ' + cell.y;
+        msg += 'Asset ' + data.x + ', ' + data.y;
         msg += '</h1>';
         // use parseFloat to be safe of XSS
-        msg += cell.value;
+        msg += data.value;
         return msg;
       },
 


### PR DESCRIPTION
Adding support for custom keys set by the seriesConfig/completeSeriesConfig object.  The chartData and seriesConfig objects can now be used the same way they are used in other predix charts.

One difference in the case of the heatmap is the addition of the `value` property that must be defined for each chartData item.  The `value` property works the same as the `x` and `y` properties do.  It is the actual value of the cell (decides which color is used).

```
const seriesConfig = {
  'series1': {
    'name': 'Series 1',
    'x': 'time',
    'y': 'asset',
    'value': 'temp'
  }
};

const chartData = [
  {
    time: '1:00',
    asset: 'Asset 1',
    temp: 0
  },
  {
    time: '1:00',
    asset: 'Asset 2',
    temp: 10
  },
  {
    time: '2:00',
    asset: 'Asset 1',
    temp: 20
  },
  {
    time: '2:00',
    asset: 'Asset 2',
    temp: 30
  }
];
```